### PR TITLE
fix more than 1 step rescaling

### DIFF
--- a/src/seal/evaluator.cpp
+++ b/src/seal/evaluator.cpp
@@ -2074,7 +2074,7 @@ namespace seal
             while (encrypted.parms_id() != parms_id)
             {
                 // Modulus switching with scaling
-                mod_switch_scale_to_next(encrypted, encrypted, move(pool));
+                mod_switch_scale_to_next(encrypted, encrypted, pool);
             }
             return;
 


### PR DESCRIPTION
The previous version will throw exception "pool is uninitialized" when "rescale_to_inplace" is called to rescale 2 or more steps down the chain.

Reason: In Evaluator::rescale_to_inplace,
```
case scheme_type::CKKS:
            while (encrypted.parms_id() != parms_id)
            {
                // Modulus switching with scaling
                mod_switch_scale_to_next(encrypted, encrypted, move(pool));
            }
```
In the while loop, if we already "move" the pool, we cannot use it again in the next iteration.