### PR TITLE
Bugfixing KeyGenerator constructors

### DIFF
--- a/native/src/seal/keygenerator.h
+++ b/native/src/seal/keygenerator.h
@@ -177,8 +177,12 @@ namespace seal
 
         /**
         Generates new secret key.
+
+        @param[in] is_initialized True if the secret_key_ has already been initialized so that only the
+         secret_key_array_ should be initialized (it may be the case, for instance, if the secret_key_
+         was provided in the constructor
         */
-        void generate_sk();
+        void generate_sk(bool is_initialized = false);
 
         /**
         Generates new public key matching to existing secret key.


### PR DESCRIPTION
When `secretKey` is provided in the `KeyGenerator` constructor, some of the internal variables are not properly initialized. Specifically, `secret_key_array_` remains uninitialized, because `generate_sk` function is never called. This, in turn, breaks generation of the reliniarization keys.
I also added a couple of unit tests that capture this problem.