### PR TITLE
Fix variable name in SEAL_DIVIDE_UINT128_UINT64 macro

### DIFF
--- a/native/src/seal/util/clang.h
+++ b/native/src/seal/util/clang.h
@@ -44,8 +44,8 @@
     n -= q * denominator;                                                           \
     numerator[0] = static_cast<std::uint64_t>(n);                                   \
     numerator[1] = static_cast<std::uint64_t>(n >> 64);                             \
-    quotient[0] = static_cast<std::uint64_t>(q);                                    \
-    quotient[1] = static_cast<std::uint64_t>(q >> 64);                              \
+    result[0] = static_cast<std::uint64_t>(q);                                      \
+    result[1] = static_cast<std::uint64_t>(q >> 64);                                \
 }
 #endif
 

--- a/native/src/seal/util/gcc.h
+++ b/native/src/seal/util/gcc.h
@@ -48,8 +48,8 @@
     n -= q * denominator;                                                           \
     numerator[0] = static_cast<std::uint64_t>(n);                                   \
     numerator[1] = static_cast<std::uint64_t>(n >> 64);                             \
-    quotient[0] = static_cast<std::uint64_t>(q);                                    \
-    quotient[1] = static_cast<std::uint64_t>(q >> 64);                              \
+    result[0] = static_cast<std::uint64_t>(q);                                      \
+    result[1] = static_cast<std::uint64_t>(q >> 64);                                \
 }
 #endif
 


### PR DESCRIPTION
The `SEAL_DIVIDE_UINT128_UINT64` macro implementation used the variable
name `quotient` instead of `result` in the macro's body.  This actually
went undetected because the only usage of that macro (in uintarith.h)
used `quotient` as the argument.