### PR TITLE
Remove public_key from doc about KeyGen constructor

### DIFF
--- a/native/src/seal/keygenerator.h
+++ b/native/src/seal/keygenerator.h
@@ -51,8 +51,8 @@ namespace seal
         @param[in] context The SEALContext
         @param[in] secret_key A previously generated secret key
         @throws std::invalid_argument if encryption parameters are not valid
-        @throws std::invalid_argument if secret_key or public_key is not valid
-        for encryption parameters
+        @throws std::invalid_argument if secret_key is not valid for encryption
+        parameters
         */
         KeyGenerator(std::shared_ptr<SEALContext> context, const SecretKey &secret_key);
 


### PR DESCRIPTION
The `KeyGenerator(std::shared_ptr<SEALContext> context, const SecretKey &secret_key)` constructor no longer take public_key as input, invalid_argument is now longer thrown if an invalid public_key is passed.

Doesn't this need to be listed in the API changes in the release?