### PR TITLE
Use lazy reduction in divide_and_round_q_last_ntt_inplace 

### DIFF
--- a/native/src/seal/util/rns.cpp
+++ b/native/src/seal/util/rns.cpp
@@ -810,24 +810,34 @@ namespace seal
             uint64_t *temp_ptr = temp.get();
             for (size_t i = 0; i < base_q_size - 1; i++)
             {
+                const uint64_t qi = (*base_q_)[i].value();
                 // (ct mod qk) mod qi
-                modulo_poly_coeffs_63(last_ptr, coeff_count_, (*base_q_)[i], temp_ptr);
-
-                uint64_t half_mod = barrett_reduce_63(half, (*base_q_)[i]);
-                for (size_t j = 0; j < coeff_count_; j++)
-                {
-                    temp_ptr[j] = sub_uint_uint_mod(temp_ptr[j], half_mod, (*base_q_)[i]);
+                if (qi < last_modulus.value()) {
+                    modulo_poly_coeffs_63(last_ptr, coeff_count_, (*base_q_)[i], temp_ptr);
+                } else {
+                    set_uint_uint(last_ptr, coeff_count_, temp_ptr);
                 }
-
+                
+                // lazy subtraction here. ntt_negacyclic_harvey_lazy can take 0 < x < 4*qi input.
+                const uint64_t neg_half_mod = qi - barrett_reduce_63(half, (*base_q_)[i]);
+                std::transform(temp_ptr, temp_ptr + coeff_count_, temp_ptr, [neg_half_mod](uint64_t u) { return u + neg_half_mod; });
+#if SEAL_USER_MOD_BIT_COUNT_MAX <= 60
+                // Since now SEAL use at most 60bit moduli, so 8*qi < 2^63.
+                // This ntt_negacyclic_harvey_lazy results in [0, 4*qi).
+                const uint64_t Lqi = qi << 2;
+                ntt_negacyclic_harvey_lazy(temp_ptr, rns_ntt_tables[i]);
+#else
+                const uint64_t Lqi = qi << 1;
                 ntt_negacyclic_harvey(temp_ptr, rns_ntt_tables[i]);
-
-                sub_poly_poly_coeffmod(
-                    input + (i * coeff_count_), temp_ptr, coeff_count_, (*base_q_)[i], input + (i * coeff_count_));
-
+#endif
+                // lazy subtraction again, results in [0, 2*Lqi), 
+                // The reduction [0, 2*Lqi) -> [0, qi) is done implicitly in multiply_poly_scalar_coeffmod.
+                std::transform(input, input + coeff_count_, temp_ptr, input, 
+                               [Lqi](uint64_t u, uint64_t v) { return u + Lqi - v; });
+                
                 // qk^(-1) * ((ct mod qi) - (ct mod qk)) mod qi
-                multiply_poly_scalar_coeffmod(
-                    input + (i * coeff_count_), coeff_count_, inv_q_last_mod_q_[i], (*base_q_)[i],
-                    input + (i * coeff_count_));
+                multiply_poly_scalar_coeffmod(input, coeff_count_, inv_q_last_mod_q_[i], (*base_q_)[i], input);
+                input += coeff_count_;
             }
         }
 


### PR DESCRIPTION

* Work for 60bit moduli. Before the multiplication with scalar, we can work in the range [0, 8*qi) without any reduction.
* ~23% faster ckks.rescaling.