### PR TITLE
Use lazy reduction divide_and_round_q_last_ntt_inplace.

### DIFF
--- a/native/src/seal/util/rns.cpp
+++ b/native/src/seal/util/rns.cpp
@@ -810,24 +810,38 @@ namespace seal
             uint64_t *temp_ptr = temp.get();
             for (size_t i = 0; i < base_q_size - 1; i++)
             {
+                const uint64_t qi = (*base_q_)[i].value();
                 // (ct mod qk) mod qi
-                modulo_poly_coeffs_63(last_ptr, coeff_count_, (*base_q_)[i], temp_ptr);
-
-                uint64_t half_mod = barrett_reduce_63(half, (*base_q_)[i]);
-                for (size_t j = 0; j < coeff_count_; j++)
-                {
-                    temp_ptr[j] = sub_uint_uint_mod(temp_ptr[j], half_mod, (*base_q_)[i]);
+                if (qi < last_modulus.value()) {
+                    modulo_poly_coeffs_63(last_ptr, coeff_count_, (*base_q_)[i], temp_ptr);
+                } else {
+                    set_uint_uint(last_ptr, coeff_count_, temp_ptr);
                 }
-
-                ntt_negacyclic_harvey(temp_ptr, rns_ntt_tables[i]);
-
-                sub_poly_poly_coeffmod(
-                    input + (i * coeff_count_), temp_ptr, coeff_count_, (*base_q_)[i], input + (i * coeff_count_));
-
+                
+                // lazy subtraction here. ntt_negacyclic_harvey_lazy can take 0 < x < 4*qi input.
+                const uint64_t neg_half_mod = qi - barrett_reduce_63(half, (*base_q_)[i]);
+                std::transform(temp_ptr, temp_ptr + coeff_count_, temp_ptr, [neg_half_mod](uint64_t u) { return u + neg_half_mod; });
+#if SEAL_USER_MOD_BIT_COUNT_MAX <= 60
+                // Since now SEAL use at most 60bit moduli, so 8*qi < 2^63.
+                // This ntt_negacyclic_harvey_lazy results in [0, 4*qi).
+                const uint64_t Lqi = qi << 2;
+                ntt_negacyclic_harvey_lazy(temp_ptr, rns_ntt_tables[i]);
+#else 
+                // 2^60 < pi < 2^62, then 4*pi < 2^64, we perfrom one reduction from [0, 4*qi) to [0, 2*qi) after ntt.
+                const uint64_t Lqi = qi << 1;
+                ntt_negacyclic_harvey_lazy(temp_ptr, rns_ntt_tables[i]);
+                std::transform(temp_ptr, temp_ptr + coeff_count_, temp_ptr, [Lqi](uint64_t u) {
+                               return u -= (Lqi & static_cast<uint64_t>(-static_cast<int64_t>(u >= Lqi)));
+                               });
+#endif
+                // lazy subtraction again, results in [0, 2*Lqi), 
+                // The reduction [0, 2*Lqi) -> [0, qi) is done implicitly in multiply_poly_scalar_coeffmod.
+                std::transform(input, input + coeff_count_, temp_ptr, input, 
+                               [Lqi](uint64_t u, uint64_t v) { return u + Lqi - v; });
+                
                 // qk^(-1) * ((ct mod qi) - (ct mod qk)) mod qi
-                multiply_poly_scalar_coeffmod(
-                    input + (i * coeff_count_), coeff_count_, inv_q_last_mod_q_[i], (*base_q_)[i],
-                    input + (i * coeff_count_));
+                multiply_poly_scalar_coeffmod(input, coeff_count_, inv_q_last_mod_q_[i], (*base_q_)[i], input);
+                input += coeff_count_;
             }
         }
 


### PR DESCRIPTION
* Work for pi < 2^60 moduli.
* Obtain 26% -- 37% performance gain in CKKS.rescale.
* Obtain 10%~ performance gain in CKKS.keyswitch

Comparing CKKS.rescale 

|degree|#moduli|before(us)|after(us)|speedup|
|---|----|---|----|---|
|32768|15|25099|17775|1.41x|
|16384|8|6085|4436|1.37x|
|8192|4|1456|1069|1.36x|
|4096|2|299|237|1.26x|

