### PR TITLE
Replace costly global statics with local statics

### DIFF
--- a/native/src/seal/memorymanager.cpp
+++ b/native/src/seal/memorymanager.cpp
@@ -7,7 +7,6 @@ using namespace std;
 
 namespace seal
 {
-    unique_ptr<MMProf> MemoryManager::mm_prof_{ new MMProfGlobal };
 #ifndef _M_CEE
     mutex MemoryManager::switch_mutex_;
 #else

--- a/native/src/seal/memorymanager.h
+++ b/native/src/seal/memorymanager.h
@@ -499,7 +499,7 @@ namespace seal
             default:
 #ifdef SEAL_DEBUG
             {
-                auto pool = mm_prof_->get_pool(prof_opt);
+                auto pool = GetMMProf()->get_pool(prof_opt);
                 if (!pool)
                 {
                     throw std::logic_error("cannot return uninitialized pool");
@@ -507,7 +507,7 @@ namespace seal
                 return pool;
             }
 #endif
-                return mm_prof_->get_pool(prof_opt);
+                return GetMMProf()->get_pool(prof_opt);
             }
         }
 
@@ -523,8 +523,8 @@ namespace seal
             {
                 throw std::invalid_argument("mm_prof cannot be null");
             }
-            auto ret_mm_prof = std::move(mm_prof_);
-            mm_prof_.reset(mm_prof);
+            auto ret_mm_prof = std::move(GetMMProf());
+            GetMMProf().reset(mm_prof);
             return ret_mm_prof;
         }
 
@@ -535,11 +535,15 @@ namespace seal
             {
                 throw std::invalid_argument("mm_prof cannot be null");
             }
-            std::swap(mm_prof_, mm_prof);
+            std::swap(GetMMProf(), mm_prof);
             return std::move(mm_prof);
         }
 
-        static std::unique_ptr<MMProf> mm_prof_;
+        SEAL_NODISCARD static inline std::unique_ptr<MMProf> &GetMMProf()
+        {
+            static std::unique_ptr<MMProf> mm_prof{ new MMProfGlobal };
+            return mm_prof;
+        }
 #ifndef _M_CEE
         static std::mutex switch_mutex_;
 #endif

--- a/native/src/seal/modulus.cpp
+++ b/native/src/seal/modulus.cpp
@@ -118,13 +118,13 @@ namespace seal
         switch (sec_level)
         {
         case sec_level_type::tc128:
-            return global_variables::default_coeff_modulus_128.at(poly_modulus_degree);
+            return global_variables::GetDefaultCoeffModulus128().at(poly_modulus_degree);
 
         case sec_level_type::tc192:
-            return global_variables::default_coeff_modulus_192.at(poly_modulus_degree);
+            return global_variables::GetDefaultCoeffModulus192().at(poly_modulus_degree);
 
         case sec_level_type::tc256:
-            return global_variables::default_coeff_modulus_256.at(poly_modulus_degree);
+            return global_variables::GetDefaultCoeffModulus256().at(poly_modulus_degree);
 
         default:
             throw runtime_error("invalid security level");

--- a/native/src/seal/util/globals.cpp
+++ b/native/src/seal/util/globals.cpp
@@ -19,150 +19,165 @@ namespace seal
 #else
 #pragma message("WARNING: Thread-local memory pools disabled to support /clr")
 #endif
-            const map<size_t, vector<Modulus>> default_coeff_modulus_128{
-                /*
-                Polynomial modulus: 1x^1024 + 1
-                Modulus count: 1
-                Total bit count: 27
-                */
-                { 1024, { 0x7e00001 } },
+            const std::map<std::size_t, std::vector<Modulus>>& GetDefaultCoeffModulus128()
+            {
+                static const map<size_t, vector<Modulus>> default_coeff_modulus_128{
+                    /*
+                    Polynomial modulus: 1x^1024 + 1
+                    Modulus count: 1
+                    Total bit count: 27
+                    */
+                    { 1024, { 0x7e00001 } },
 
-                /*
-                Polynomial modulus: 1x^2048 + 1
-                Modulus count: 1
-                Total bit count: 54
-                */
-                { 2048, { 0x3fffffff000001 } },
+                    /*
+                    Polynomial modulus: 1x^2048 + 1
+                    Modulus count: 1
+                    Total bit count: 54
+                    */
+                    { 2048, { 0x3fffffff000001 } },
 
-                /*
-                Polynomial modulus: 1x^4096 + 1
-                Modulus count: 3
-                Total bit count: 109 = 2 * 36 + 37
-                */
-                { 4096, { 0xffffee001, 0xffffc4001, 0x1ffffe0001 } },
+                    /*
+                    Polynomial modulus: 1x^4096 + 1
+                    Modulus count: 3
+                    Total bit count: 109 = 2 * 36 + 37
+                    */
+                    { 4096, { 0xffffee001, 0xffffc4001, 0x1ffffe0001 } },
 
-                /*
-                Polynomial modulus: 1x^8192 + 1
-                Modulus count: 5
-                Total bit count: 218 = 2 * 43 + 3 * 44
-                */
-                { 8192, { 0x7fffffd8001, 0x7fffffc8001, 0xfffffffc001, 0xffffff6c001, 0xfffffebc001 } },
+                    /*
+                    Polynomial modulus: 1x^8192 + 1
+                    Modulus count: 5
+                    Total bit count: 218 = 2 * 43 + 3 * 44
+                    */
+                    { 8192, { 0x7fffffd8001, 0x7fffffc8001, 0xfffffffc001, 0xffffff6c001, 0xfffffebc001 } },
 
-                /*
-                Polynomial modulus: 1x^16384 + 1
-                Modulus count: 9
-                Total bit count: 438 = 3 * 48 + 6 * 49
-                */
-                { 16384,
-                  { 0xfffffffd8001, 0xfffffffa0001, 0xfffffff00001, 0x1fffffff68001, 0x1fffffff50001, 0x1ffffffee8001,
-                    0x1ffffffea0001, 0x1ffffffe88001, 0x1ffffffe48001 } },
+                    /*
+                    Polynomial modulus: 1x^16384 + 1
+                    Modulus count: 9
+                    Total bit count: 438 = 3 * 48 + 6 * 49
+                    */
+                    { 16384,
+                      { 0xfffffffd8001, 0xfffffffa0001, 0xfffffff00001, 0x1fffffff68001, 0x1fffffff50001,
+                        0x1ffffffee8001, 0x1ffffffea0001, 0x1ffffffe88001, 0x1ffffffe48001 } },
 
-                /*
-                Polynomial modulus: 1x^32768 + 1
-                Modulus count: 16
-                Total bit count: 881 = 15 * 55 + 56
-                */
-                { 32768,
-                  { 0x7fffffffe90001, 0x7fffffffbf0001, 0x7fffffffbd0001, 0x7fffffffba0001, 0x7fffffffaa0001,
-                    0x7fffffffa50001, 0x7fffffff9f0001, 0x7fffffff7e0001, 0x7fffffff770001, 0x7fffffff380001,
-                    0x7fffffff330001, 0x7fffffff2d0001, 0x7fffffff170001, 0x7fffffff150001, 0x7ffffffef00001,
-                    0xfffffffff70001 } }
-            };
+                    /*
+                    Polynomial modulus: 1x^32768 + 1
+                    Modulus count: 16
+                    Total bit count: 881 = 15 * 55 + 56
+                    */
+                    { 32768,
+                      { 0x7fffffffe90001, 0x7fffffffbf0001, 0x7fffffffbd0001, 0x7fffffffba0001, 0x7fffffffaa0001,
+                        0x7fffffffa50001, 0x7fffffff9f0001, 0x7fffffff7e0001, 0x7fffffff770001, 0x7fffffff380001,
+                        0x7fffffff330001, 0x7fffffff2d0001, 0x7fffffff170001, 0x7fffffff150001, 0x7ffffffef00001,
+                        0xfffffffff70001 } }
+                };
 
-            const map<size_t, vector<Modulus>> default_coeff_modulus_192{
-                /*
-                Polynomial modulus: 1x^1024 + 1
-                Modulus count: 1
-                Total bit count: 19
-                */
-                { 1024, { 0x7f001 } },
+                return default_coeff_modulus_128;
+            }
 
-                /*
-                Polynomial modulus: 1x^2048 + 1
-                Modulus count: 1
-                Total bit count: 37
-                */
-                { 2048, { 0x1ffffc0001 } },
+            const map<size_t, vector<Modulus>>& GetDefaultCoeffModulus192()
+            {
+                static const map<size_t, vector<Modulus>> default_coeff_modulus_192{
+                    /*
+                    Polynomial modulus: 1x^1024 + 1
+                    Modulus count: 1
+                    Total bit count: 19
+                    */
+                    { 1024, { 0x7f001 } },
 
-                /*
-                Polynomial modulus: 1x^4096 + 1
-                Modulus count: 3
-                Total bit count: 75 = 3 * 25
-                */
-                { 4096, { 0x1ffc001, 0x1fce001, 0x1fc0001 } },
+                    /*
+                    Polynomial modulus: 1x^2048 + 1
+                    Modulus count: 1
+                    Total bit count: 37
+                    */
+                    { 2048, { 0x1ffffc0001 } },
 
-                /*
-                Polynomial modulus: 1x^8192 + 1
-                Modulus count: 4
-                Total bit count: 152 = 4 * 38
-                */
-                { 8192, { 0x3ffffac001, 0x3ffff54001, 0x3ffff48001, 0x3ffff28001 } },
+                    /*
+                    Polynomial modulus: 1x^4096 + 1
+                    Modulus count: 3
+                    Total bit count: 75 = 3 * 25
+                    */
+                    { 4096, { 0x1ffc001, 0x1fce001, 0x1fc0001 } },
 
-                /*
-                Polynomial modulus: 1x^16384 + 1
-                Modulus count: 6
-                Total bit count: 300 = 6 * 50
-                */
-                { 16384,
-                  { 0x3ffffffdf0001, 0x3ffffffd48001, 0x3ffffffd20001, 0x3ffffffd18001, 0x3ffffffcd0001,
-                    0x3ffffffc70001 } },
+                    /*
+                    Polynomial modulus: 1x^8192 + 1
+                    Modulus count: 4
+                    Total bit count: 152 = 4 * 38
+                    */
+                    { 8192, { 0x3ffffac001, 0x3ffff54001, 0x3ffff48001, 0x3ffff28001 } },
 
-                /*
-                Polynomial modulus: 1x^32768 + 1
-                Modulus count: 11
-                Total bit count: 600 = 5 * 54 + 6 * 55
-                */
-                { 32768,
-                  { 0x3fffffffd60001, 0x3fffffffca0001, 0x3fffffff6d0001, 0x3fffffff5d0001, 0x3fffffff550001,
-                    0x7fffffffe90001, 0x7fffffffbf0001, 0x7fffffffbd0001, 0x7fffffffba0001, 0x7fffffffaa0001,
-                    0x7fffffffa50001 } }
-            };
+                    /*
+                    Polynomial modulus: 1x^16384 + 1
+                    Modulus count: 6
+                    Total bit count: 300 = 6 * 50
+                    */
+                    { 16384,
+                      { 0x3ffffffdf0001, 0x3ffffffd48001, 0x3ffffffd20001, 0x3ffffffd18001, 0x3ffffffcd0001,
+                        0x3ffffffc70001 } },
 
-            const map<size_t, vector<Modulus>> default_coeff_modulus_256{
-                /*
-                Polynomial modulus: 1x^1024 + 1
-                Modulus count: 1
-                Total bit count: 14
-                */
-                { 1024, { 0x3001 } },
+                    /*
+                    Polynomial modulus: 1x^32768 + 1
+                    Modulus count: 11
+                    Total bit count: 600 = 5 * 54 + 6 * 55
+                    */
+                    { 32768,
+                      { 0x3fffffffd60001, 0x3fffffffca0001, 0x3fffffff6d0001, 0x3fffffff5d0001, 0x3fffffff550001,
+                        0x7fffffffe90001, 0x7fffffffbf0001, 0x7fffffffbd0001, 0x7fffffffba0001, 0x7fffffffaa0001,
+                        0x7fffffffa50001 } }
+                };
 
-                /*
-                Polynomial modulus: 1x^2048 + 1
-                Modulus count: 1
-                Total bit count: 29
-                */
-                { 2048, { 0x1ffc0001 } },
+                return default_coeff_modulus_192;
+            }
 
-                /*
-                Polynomial modulus: 1x^4096 + 1
-                Modulus count: 1
-                Total bit count: 58
-                */
-                { 4096, { 0x3ffffffff040001 } },
+            const map<size_t, vector<Modulus>>& GetDefaultCoeffModulus256()
+            {
+                static const map<size_t, vector<Modulus>> default_coeff_modulus_256{
+                    /*
+                    Polynomial modulus: 1x^1024 + 1
+                    Modulus count: 1
+                    Total bit count: 14
+                    */
+                    { 1024, { 0x3001 } },
 
-                /*
-                Polynomial modulus: 1x^8192 + 1
-                Modulus count: 3
-                Total bit count: 118 = 2 * 39 + 40
-                */
-                { 8192, { 0x7ffffec001, 0x7ffffb0001, 0xfffffdc001 } },
+                    /*
+                    Polynomial modulus: 1x^2048 + 1
+                    Modulus count: 1
+                    Total bit count: 29
+                    */
+                    { 2048, { 0x1ffc0001 } },
 
-                /*
-                Polynomial modulus: 1x^16384 + 1
-                Modulus count: 5
-                Total bit count: 237 = 3 * 47 + 2 * 48
-                */
-                { 16384, { 0x7ffffffc8001, 0x7ffffff00001, 0x7fffffe70001, 0xfffffffd8001, 0xfffffffa0001 } },
+                    /*
+                    Polynomial modulus: 1x^4096 + 1
+                    Modulus count: 1
+                    Total bit count: 58
+                    */
+                    { 4096, { 0x3ffffffff040001 } },
 
-                /*
-                Polynomial modulus: 1x^32768 + 1
-                Modulus count: 9
-                Total bit count: 476 = 52 + 8 * 53
-                */
-                { 32768,
-                  { 0xffffffff00001, 0x1fffffffe30001, 0x1fffffffd80001, 0x1fffffffd10001, 0x1fffffffc50001,
-                    0x1fffffffbf0001, 0x1fffffffb90001, 0x1fffffffb60001, 0x1fffffffa50001 } }
-            };
+                    /*
+                    Polynomial modulus: 1x^8192 + 1
+                    Modulus count: 3
+                    Total bit count: 118 = 2 * 39 + 40
+                    */
+                    { 8192, { 0x7ffffec001, 0x7ffffb0001, 0xfffffdc001 } },
+
+                    /*
+                    Polynomial modulus: 1x^16384 + 1
+                    Modulus count: 5
+                    Total bit count: 237 = 3 * 47 + 2 * 48
+                    */
+                    { 16384, { 0x7ffffffc8001, 0x7ffffff00001, 0x7fffffe70001, 0xfffffffd8001, 0xfffffffa0001 } },
+
+                    /*
+                    Polynomial modulus: 1x^32768 + 1
+                    Modulus count: 9
+                    Total bit count: 476 = 52 + 8 * 53
+                    */
+                    { 32768,
+                      { 0xffffffff00001, 0x1fffffffe30001, 0x1fffffffd80001, 0x1fffffffd10001, 0x1fffffffc50001,
+                        0x1fffffffbf0001, 0x1fffffffb90001, 0x1fffffffb60001, 0x1fffffffa50001 } }
+                };
+
+                return default_coeff_modulus_256;
+            }
         } // namespace global_variables
     }     // namespace util
 } // namespace seal

--- a/native/src/seal/util/globals.h
+++ b/native/src/seal/util/globals.h
@@ -48,7 +48,7 @@ For .NET Framework wrapper support (C++/CLI) we need to
             level is at least 128 bits according to http://HomomorphicEncryption.org. This makes
             it easy for non-expert users to select secure parameters.
             */
-            extern const std::map<std::size_t, std::vector<Modulus>> default_coeff_modulus_128;
+            const std::map<std::size_t, std::vector<Modulus>>& GetDefaultCoeffModulus128();
 
             /**
             This data structure is a key-value storage that maps degrees of the polynomial modulus
@@ -57,7 +57,7 @@ For .NET Framework wrapper support (C++/CLI) we need to
             level is at least 192 bits according to http://HomomorphicEncryption.org. This makes
             it easy for non-expert users to select secure parameters.
             */
-            extern const std::map<std::size_t, std::vector<Modulus>> default_coeff_modulus_192;
+            const std::map<std::size_t, std::vector<Modulus>>& GetDefaultCoeffModulus192();
 
             /**
             This data structure is a key-value storage that maps degrees of the polynomial modulus
@@ -66,7 +66,7 @@ For .NET Framework wrapper support (C++/CLI) we need to
             level is at least 256 bits according to http://HomomorphicEncryption.org. This makes
             it easy for non-expert users to select secure parameters.
             */
-            extern const std::map<std::size_t, std::vector<Modulus>> default_coeff_modulus_256;
+            const std::map<std::size_t, std::vector<Modulus>>& GetDefaultCoeffModulus256();
         } // namespace global_variables
     }     // namespace util
 } // namespace seal


### PR DESCRIPTION
When investigating performance traces on Windows I noticed there is a significant CPU and reference set impact due to this library's global statics.  These get initialized on module load in every process - regardless if it uses the code.  Change is to convert these globals in static locals that are created on demand.