### PR TITLE
Memory access out of bounds

### DIFF
--- a/native/src/seal/util/common.cpp
+++ b/native/src/seal/util/common.cpp
@@ -33,8 +33,8 @@ namespace seal
             explicit_memset(data, 0, size);
 #else
             volatile SEAL_BYTE *data_ptr = reinterpret_cast<SEAL_BYTE *>(data);
-            size_t i = 0;
-            while (i < size)
+            size_t i = size;
+            while (i--)
             {
                 *data_ptr++ = static_cast<SEAL_BYTE>(0);
             }


### PR DESCRIPTION
When using SEAL **without** `SecureZeroMemory`, `explicit_bzero`, or `explicit_memset`, the code will throw an exception when `seal_memzero` is called.

In `seal_memzero` the code will never exit the loop, causing an OOB exception:

```            
            volatile SEAL_BYTE *data_ptr = reinterpret_cast<SEAL_BYTE *>(data);
            size_t i = 0;
            while (i < size) // <------ `i` is never incremented, loop never exits
            {
                *data_ptr++ = static_cast<SEAL_BYTE>(0);  // <---- OOB exception
            }
```

Solution:

```
            volatile SEAL_BYTE *data_ptr = reinterpret_cast<SEAL_BYTE *>(data);
            size_t i = size;
            while (i--)
            {
                *data_ptr++ = static_cast<SEAL_BYTE>(0);
            }
```