### PR TITLE
Memory access out of bounds

### DIFF
--- a/native/src/seal/util/common.cpp
+++ b/native/src/seal/util/common.cpp
@@ -33,8 +33,8 @@ namespace seal
             explicit_memset(data, 0, size);
 #else
             volatile SEAL_BYTE *data_ptr = reinterpret_cast<SEAL_BYTE *>(data);
-            size_t i = 0;
-            while (i < size)
+            size_t i = size;
+            while (i--)
             {
                 *data_ptr++ = static_cast<SEAL_BYTE>(0);
             }

--- a/native/src/seal/util/common.cpp
+++ b/native/src/seal/util/common.cpp
@@ -18,7 +18,7 @@ namespace seal
 {
     namespace util
     {
-        void seal_memzero(void *const data, const size_t size)
+        void seal_memzero(void *const data, size_t size)
         {
 #if SEAL_SYSTEM == SEAL_SYSTEM_WINDOWS
             SecureZeroMemory(data, size);
@@ -33,8 +33,7 @@ namespace seal
             explicit_memset(data, 0, size);
 #else
             volatile SEAL_BYTE *data_ptr = reinterpret_cast<SEAL_BYTE *>(data);
-            size_t i = size;
-            while (i--)
+            while (size--)
             {
                 *data_ptr++ = static_cast<SEAL_BYTE>(0);
             }

--- a/native/src/seal/util/common.h
+++ b/native/src/seal/util/common.h
@@ -567,6 +567,6 @@ namespace seal
             return value == T{ 0 };
         }
 
-        void seal_memzero(void *const data, const std::size_t size);
+        void seal_memzero(void *const data, std::size_t size);
     } // namespace util
 } // namespace seal


### PR DESCRIPTION
When using SEAL **without** `SecureZeroMemory`, `explicit_bzero`, or `explicit_memset`, the code will throw an exception when `seal_memzero` is called.

In `seal_memzero` the code will never exit the loop, causing an OOB exception:

```            
            volatile SEAL_BYTE *data_ptr = reinterpret_cast<SEAL_BYTE *>(data);
            size_t i = 0;
            while (i < size) // <------ `i` is never incremented, loop never exits
            {
                *data_ptr++ = static_cast<SEAL_BYTE>(0);  // <---- OOB exception
            }
```