### PR TITLE
Intrinsics for ARM64

### DIFF
--- a/cmake/CheckCXXIntrinsicsHeader.cmake
+++ b/cmake/CheckCXXIntrinsicsHeader.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
-# Check for intrin.h or x64intrin.h
+# Check for intrin.h or x86intrin.h
 if(SEAL_USE_INTRIN)
     if(MSVC)
         set(SEAL_INTRIN_HEADER "intrin.h")
@@ -19,7 +19,7 @@ if(SEAL_USE_INTRIN)
         if(SEAL_ARM64)
             set(SEAL_INTRIN_HEADER "arm_neon.h")    
         else()
-            set(SEAL_INTRIN_HEADER "x64intrin.h")
+            set(SEAL_INTRIN_HEADER "x86intrin.h")
         endif()
     endif()
 

--- a/cmake/CheckCXXIntrinsicsHeader.cmake
+++ b/cmake/CheckCXXIntrinsicsHeader.cmake
@@ -6,7 +6,21 @@ if(SEAL_USE_INTRIN)
     if(MSVC)
         set(SEAL_INTRIN_HEADER "intrin.h")
     else()
-        set(SEAL_INTRIN_HEADER "x86intrin.h")
+        #set(CMAKE_REQUIRED_QUIET TRUE)
+        check_cxx_source_runs("
+            #if defined(__x86_64__)
+                #error
+            #endif
+            int main() {
+                return 0;
+            }"
+            SEAL_ARM64
+        )
+        if(SEAL_ARM64)
+            set(SEAL_INTRIN_HEADER "arm_neon.h")    
+        else()
+            set(SEAL_INTRIN_HEADER "x64intrin.h")
+        endif()
     endif()
 
     check_include_file_cxx(${SEAL_INTRIN_HEADER} SEAL_INTRIN_HEADER_FOUND)

--- a/native/src/seal/util/clang.h
+++ b/native/src/seal/util/clang.h
@@ -15,7 +15,12 @@
 
 // Are intrinsics enabled?
 #ifdef SEAL_USE_INTRIN
+#if defined(__aarch64__)
+#include <arm_neon.h>
+#else
 #include <x86intrin.h>
+#endif
+
 
 #ifdef SEAL_USE___BUILTIN_CLZLL
 #define SEAL_MSB_INDEX_UINT64(result, value)                                 \

--- a/native/src/seal/util/gcc.h
+++ b/native/src/seal/util/gcc.h
@@ -19,7 +19,11 @@
 
 // Are intrinsics enabled?
 #ifdef SEAL_USE_INTRIN
+#if defined(__aarch64__)
+#include <arm_neon.h>
+#else
 #include <x86intrin.h>
+#endif
 
 #ifdef SEAL_USE___BUILTIN_CLZLL
 #define SEAL_MSB_INDEX_UINT64(result, value)                                 \


### PR DESCRIPTION
Following Issue #268.

- `CheckCXXIntrinsicsHeader.cmake`:  add the detection of arm64 such that the script check for `arm_neon.h` instead of `x86intrin.h` when compiling for arm64. Correction of a small typo in the comment.
- `clang.h` & `gcc.h`:  add the detection of arm64 to include to correct header file.

It seems from the documentation that the intrinsics used by MSC for x86_64 don't have equivalent for arm64, so no changes.