### PR TITLE
Fix a few typos and minor changes

### DIFF
--- a/dotnet/src/Evaluator.cs
+++ b/dotnet/src/Evaluator.cs
@@ -937,7 +937,7 @@ namespace Microsoft.Research.SEAL
         /// Multiplies a ciphertext with a plaintext and stores the result in encrypted.
         /// </summary>
         /// <remarks>
-        /// Multiplies a ciphertext with a plaintext. The plaintext cannot be identially 0. Dynamic memory allocations
+        /// Multiplies a ciphertext with a plaintext. The plaintext cannot be identically 0. Dynamic memory allocations
         /// in the process are allocated from the memory pool pointed to by the given MemoryPoolHandle.
         /// </remarks>
         /// <param name="encrypted">The ciphertext to multiply</param>
@@ -961,7 +961,7 @@ namespace Microsoft.Research.SEAL
         /// </summary>
         /// <remarks>
         /// This function multiplies a ciphertext with a plaintext and stores the result in the destination parameter.
-        /// The plaintext cannot be identially 0. Dynamic memory allocations in the process are allocated from the
+        /// The plaintext cannot be identically 0. Dynamic memory allocations in the process are allocated from the
         /// memory pool pointed to by the given MemoryPoolHandle.
         /// </remarks>
         /// <param name="encrypted">The ciphertext to multiply</param>

--- a/native/bench/bench.cpp
+++ b/native/bench/bench.cpp
@@ -102,6 +102,8 @@ namespace sealbench
 
 int main(int argc, char **argv)
 {
+    Initialize(&argc, argv);
+
     cout << "Microsoft SEAL version: " << SEAL_VERSION << endl;
     cout << "Running precomputations ..." << endl;
 
@@ -149,7 +151,6 @@ int main(int argc, char **argv)
         sealbench::register_bm_family(i, bm_env_map);
     }
 
-    Initialize(&argc, argv);
     RunSpecifiedBenchmarks();
 
     // After running all benchmark cases, we print again the total memory consumption by SEAL memory pool.

--- a/native/src/seal/evaluator.h
+++ b/native/src/seal/evaluator.h
@@ -708,7 +708,7 @@ namespace seal
         }
 
         /**
-        Multiplies a ciphertext with a plaintext. The plaintext cannot be identially 0. Dynamic memory allocations in
+        Multiplies a ciphertext with a plaintext. The plaintext cannot be identically 0. Dynamic memory allocations in
         the process are allocated from the memory pool pointed to by the given MemoryPoolHandle.
 
         @param[in] encrypted The ciphertext to multiply
@@ -725,7 +725,7 @@ namespace seal
 
         /**
         Multiplies a ciphertext with a plaintext. This function multiplies a ciphertext with a plaintext and stores the
-        result in the destination parameter. The plaintext cannot be identially 0. Dynamic memory allocations in the
+        result in the destination parameter. The plaintext cannot be identically 0. Dynamic memory allocations in the
         process are allocated from the memory pool pointed to by the given MemoryPoolHandle.
 
         @param[in] encrypted The ciphertext to multiply

--- a/native/src/seal/util/uintarithsmallmod.h
+++ b/native/src/seal/util/uintarithsmallmod.h
@@ -231,7 +231,7 @@ namespace seal
 
         /**
         Returns (operand1 * operand2) mod modulus.
-        Correctness: Follows the condition of barret_reduce_128.
+        Correctness: Follows the condition of barrett_reduce_128.
         */
         SEAL_NODISCARD inline std::uint64_t multiply_uint_mod(
             std::uint64_t operand1, std::uint64_t operand2, const Modulus &modulus)
@@ -327,7 +327,7 @@ namespace seal
 
         /**
         Returns value[0] = value mod modulus.
-        Correctness: Follows the condition of barret_reduce_128.
+        Correctness: Follows the condition of barrett_reduce_128.
         */
         inline void modulo_uint_inplace(std::uint64_t *value, std::size_t value_uint64_count, const Modulus &modulus)
         {
@@ -364,7 +364,7 @@ namespace seal
 
         /**
         Returns value mod modulus.
-        Correctness: Follows the condition of barret_reduce_128.
+        Correctness: Follows the condition of barrett_reduce_128.
         */
         SEAL_NODISCARD inline std::uint64_t modulo_uint(
             const std::uint64_t *value, std::size_t value_uint64_count, const Modulus &modulus)
@@ -402,7 +402,7 @@ namespace seal
 
         /**
         Returns (operand1 * operand2) + operand3 mod modulus.
-        Correctness: Follows the condition of barret_reduce_128.
+        Correctness: Follows the condition of barrett_reduce_128.
         */
         inline std::uint64_t multiply_add_uint_mod(
             std::uint64_t operand1, std::uint64_t operand2, std::uint64_t operand3, const Modulus &modulus)
@@ -432,22 +432,22 @@ namespace seal
 
         /**
         Returns operand^exponent mod modulus.
-        Correctness: Follows the condition of barret_reduce_128.
+        Correctness: Follows the condition of barrett_reduce_128.
         */
         SEAL_NODISCARD std::uint64_t exponentiate_uint_mod(
             std::uint64_t operand, std::uint64_t exponent, const Modulus &modulus);
 
         /**
         Computes numerator = numerator mod modulus, quotient = numerator / modulus.
-        Correctness: Follows the condition of barret_reduce_128.
+        Correctness: Follows the condition of barrett_reduce_128.
         */
         void divide_uint_mod_inplace(
             std::uint64_t *numerator, const Modulus &modulus, std::size_t uint64_count, std::uint64_t *quotient,
             MemoryPool &pool);
 
         /**
-        Computes <opearnd1, operand2> mod modulus.
-        Correctness: Follows the condition of barret_reduce_128.
+        Computes <operand1, operand2> mod modulus.
+        Correctness: Follows the condition of barrett_reduce_128.
         */
         SEAL_NODISCARD std::uint64_t dot_product_mod(
             const std::uint64_t *operand1, const std::uint64_t *operand2, std::size_t count, const Modulus &modulus);

--- a/native/tests/seal/util/rns.cpp
+++ b/native/tests/seal/util/rns.cpp
@@ -1024,7 +1024,7 @@ namespace sealtest
             vector<uint64_t> in(poly_modulus_degree * rns_tool->base_q()->size());
             set_zero_uint(in.size(), in.data());
             RNSIter in_iter(in.data(), poly_modulus_degree);
-            rns_tool->divide_and_round_q_last_inplace(in_iter, pool);
+            rns_tool->divide_and_round_q_last_ntt_inplace(in_iter, ntt, pool);
             ASSERT_EQ(0ULL, in[0]);
             ASSERT_EQ(0ULL, in[1]);
 


### PR DESCRIPTION
- Calling `Initialize` at the beginning of `main` in `bench.cpp` enables calling `./bin/sealbench --help` with quick output, rather than waiting for the pre-computation to finish.