### PR TITLE
Add WASM benchmark

### DIFF
--- a/native/bench/CMakeLists.txt
+++ b/native/bench/CMakeLists.txt
@@ -42,6 +42,10 @@ if(SEAL_BUILD_BENCH)
     endif()
 
     add_executable(sealbench)
+    # If we're targeting WASM, add the appropriate link flags
+    if(EMSCRIPTEN)
+        set_target_properties(sealbench PROPERTIES LINK_FLAGS "-flto -O3 -s WASM=1 -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB")
+    endif()
     target_sources(sealbench
         PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/bench.cpp


### PR DESCRIPTION
This PR adds small changes to CMake to allow building the benchmark code to WASM.

Note: the `LINK_FLAGS` are static which only builds a release level wasm benchmark.

Steps to build:
- Follow the new emscripten steps, but add the flag`-DSEAL_BUILD_BENCH=ON` to `emcmake cmake ...`
- Run `emmake make -j`
- See the two output files generated in `<seal root>/bin/sealbench.js|wasm` 
- Run with `node sealbench.js`

## Next Steps

Parameterize the link flags. This would allow flexible builds for debugging WASM.