### PR TITLE
Fix clang alloc-dealloc-mismatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -226,6 +226,17 @@ if(SEAL_USE_INTEL_HEXL)
     endif()
 endif()
 
+# [option] SEAL_USE_ADDRESS_SANITIZER (default: OFF)
+option(SEAL_USE_ADDRESS_SANITIZER_OPTION_STR "Compiles and links with Address Sanitizer" OFF)
+option(SEAL_USE_ADDRESS_SANITIZER ${SEAL_USE_ADDRESS_SANITIZER_OPTION_STR} OFF)
+message(STATUS "SEAL_USE_ADDRESS_SANITIZER: ${SEAL_USE_ADDRESS_SANITIZER}")
+
+if(SEAL_USE_ADDRESS_SANITIZER)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address -fsanitize=leak")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address -fsanitize=leak")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address -fsanitize=leak")
+endif()
+
 ####################
 # SEAL C++ library #
 ####################

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ The following options can be used with CMake to configure the build. The default
 | SEAL_BUILD_SEAL_C      | ON / **OFF**                                                 | Build the C wrapper library SEAL_C. This is used by the C# wrapper and most users should have no reason to build it.                                                                                   |
 | SEAL_USE_CXX17         | **ON** / OFF                                                 | Set to `ON` to build Microsoft SEAL as C++17 for a positive performance impact.                                                                                                                        |
 | SEAL_USE_INTRIN        | **ON** / OFF                                                 | Set to `ON` to use compiler intrinsics for improved performance. CMake will automatically detect which intrinsics are available and enable them accordingly.                                           |
+| SEAL_USE_ADDRESS_SANITIZER | ON / *OFF*                                               | Set to `ON` to enable [AddressSanitizer](https://github.com/google/sanitizers) for diagnosing memory corruption issues
 
 As usual, these options can be passed to CMake with the `-D` flag.
 For example, one could run

--- a/native/src/seal/util/clang.h
+++ b/native/src/seal/util/clang.h
@@ -17,6 +17,7 @@
 #include <cstdlib>
 #define SEAL_MALLOC(size) \
     static_cast<seal_byte *>((((size)&63) == 0) ? ::aligned_alloc(64, (size)) : std::malloc((size)))
+#define SEAL_FREE(ptr) std::free(ptr)
 #endif
 
 // Are intrinsics enabled?

--- a/native/src/seal/util/defines.h
+++ b/native/src/seal/util/defines.h
@@ -163,7 +163,7 @@ namespace seal
 
 // Allocate "size" bytes in memory and returns a seal_byte pointer
 // If SEAL_USE_ALIGNED_ALLOC is defined, use _aligned_malloc and ::aligned_alloc (or std::malloc)
-// Use `new sealbytes[size]` as fallback
+// Use `new seal_byte[size]` as fallback
 #ifndef SEAL_MALLOC
 #define SEAL_MALLOC(size) (new seal_byte[size])
 #endif


### PR DESCRIPTION
When compiling with clang-10, the recent aligned malloc changes seem to have a mismatch, using `malloc` / `delete[]`, as evidenced by the [AddressSanitizer (Asan)](https://github.com/google/sanitizers) output below. This PR fixes the issue.

This PR also an option to enable Asan. Now, the tests pass with `-DSEAL_USE_ADDRESS_SANITIZER=ON`. Note, Asan adds a significant performance penalty, so any benchmarking results should be run with `-DSEAL_USE_ADDRESS_SANITIZER=OFF`. I'm happy to remove this option, just figured I'd point it out as a useful tool in case you'd like to add it to SEAL.

```
==437185==ERROR: AddressSanitizer: alloc-dealloc-mismatch (malloc vs operator delete []) on 0x7f6559275800
    #0 0x52cffd in operator delete[](void*) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x52cffd)
    #1 0xef326d in seal::util::MemoryPoolHeadMT::~MemoryPoolHeadMT() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0xef326d)
    #2 0xef33c8 in seal::util::MemoryPoolHeadMT::~MemoryPoolHeadMT() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0xef33c8)
    #3 0xef4aa1 in seal::util::MemoryPoolMT::~MemoryPoolMT() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0xef4aa1)
    #4 0xed661b in seal::Serialization::Save(std::function<void (std::ostream&)>, long, std::ostream&, seal::compr_mode_type, bool) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0xed661b)
    #5 0x53e37f in sealtest::CiphertextTest_SaveLoadCiphertext_Test::TestBody() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x53e37f)
    #6 0x108ff01 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x108ff01)
    #7 0x101cd5b in testing::Test::Run() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x101cd5b)
    #8 0x1020952 in testing::TestInfo::Run() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x1020952)
    #9 0x1022200 in testing::TestSuite::Run() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x1022200)
    #10 0x105058c in testing::internal::UnitTestImpl::RunAllTests() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x105058c)
    #11 0x10925c7 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x10925c7)
    #12 0x104f5a6 in testing::UnitTest::Run() (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x104f5a6)
    #13 0xac091a in main (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0xac091a)
    #14 0x7f655bfb50b2 in __libc_start_main /build/glibc-eX1tMB/glibc-2.31/csu/../csu/libc-start.c:308:16
    #15 0x4847ed in _start (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x4847ed)

0x7f6559275800 is located 0 bytes inside of 262144-byte region [0x7f6559275800,0x7f65592b5800)
allocated by thread T0 here:
    #0 0x4fd852 in aligned_alloc (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x4fd852)
    #1 0xef2d4d in seal::util::MemoryPoolHeadMT::MemoryPoolHeadMT(unsigned long, bool) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0xef2d4d)
    #2 0xef50c5 in seal::util::MemoryPoolMT::get_for_byte_count(unsigned long) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0xef50c5)
    #3 0x9955df in seal::DynArray<std::byte>::resize(unsigned long, bool) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x9955df)
    #4 0x994c17 in seal::DynArray<std::byte>::DynArray(unsigned long, seal::MemoryPoolHandle) (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x994c17)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch (/home/fboemer/repos/XXXX/intel-seal/build/bin/sealtest+0x52cffd) in operator delete[](void*)
==437185==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==437185==ABORTING
```