### PR TITLE
add const qualifier to Evaluator and BatchEncoder functions

### DIFF
--- a/native/src/seal/batchencoder.cpp
+++ b/native/src/seal/batchencoder.cpp
@@ -107,7 +107,7 @@ namespace seal
         }
     }
 
-    void BatchEncoder::encode(const vector<uint64_t> &values_matrix, Plaintext &destination)
+    void BatchEncoder::encode(const vector<uint64_t> &values_matrix, Plaintext &destination) const
     {
         auto &context_data = *context_.first_context_data();
 
@@ -148,7 +148,7 @@ namespace seal
         inverse_ntt_negacyclic_harvey(destination.data(), *context_data.plain_ntt_tables());
     }
 
-    void BatchEncoder::encode(const vector<int64_t> &values_matrix, Plaintext &destination)
+    void BatchEncoder::encode(const vector<int64_t> &values_matrix, Plaintext &destination) const
     {
         auto &context_data = *context_.first_context_data();
         uint64_t modulus = context_data.parms().plain_modulus().value();
@@ -192,7 +192,7 @@ namespace seal
         inverse_ntt_negacyclic_harvey(destination.data(), *context_data.plain_ntt_tables());
     }
 #ifdef SEAL_USE_MSGSL
-    void BatchEncoder::encode(gsl::span<const uint64_t> values_matrix, Plaintext &destination)
+    void BatchEncoder::encode(gsl::span<const uint64_t> values_matrix, Plaintext &destination) const
     {
         auto &context_data = *context_.first_context_data();
 
@@ -232,7 +232,7 @@ namespace seal
         inverse_ntt_negacyclic_harvey(destination.data(), *context_data.plain_ntt_tables());
     }
 
-    void BatchEncoder::encode(gsl::span<const int64_t> values_matrix, Plaintext &destination)
+    void BatchEncoder::encode(gsl::span<const int64_t> values_matrix, Plaintext &destination) const
     {
         auto &context_data = *context_.first_context_data();
         uint64_t modulus = context_data.parms().plain_modulus().value();
@@ -275,7 +275,7 @@ namespace seal
         inverse_ntt_negacyclic_harvey(destination.data(), *context_data.plain_ntt_tables());
     }
 #endif
-    void BatchEncoder::decode(const Plaintext &plain, vector<uint64_t> &destination, MemoryPoolHandle pool)
+    void BatchEncoder::decode(const Plaintext &plain, vector<uint64_t> &destination, MemoryPoolHandle pool) const
     {
         if (!is_valid_for(plain, context_))
         {
@@ -314,7 +314,7 @@ namespace seal
         }
     }
 
-    void BatchEncoder::decode(const Plaintext &plain, vector<int64_t> &destination, MemoryPoolHandle pool)
+    void BatchEncoder::decode(const Plaintext &plain, vector<int64_t> &destination, MemoryPoolHandle pool) const
     {
         if (!is_valid_for(plain, context_))
         {
@@ -358,7 +358,7 @@ namespace seal
         }
     }
 #ifdef SEAL_USE_MSGSL
-    void BatchEncoder::decode(const Plaintext &plain, gsl::span<uint64_t> destination, MemoryPoolHandle pool)
+    void BatchEncoder::decode(const Plaintext &plain, gsl::span<uint64_t> destination, MemoryPoolHandle pool) const
     {
         if (!is_valid_for(plain, context_))
         {
@@ -399,7 +399,7 @@ namespace seal
         }
     }
 
-    void BatchEncoder::decode(const Plaintext &plain, gsl::span<int64_t> destination, MemoryPoolHandle pool)
+    void BatchEncoder::decode(const Plaintext &plain, gsl::span<int64_t> destination, MemoryPoolHandle pool) const
     {
         if (!is_valid_for(plain, context_))
         {

--- a/native/src/seal/batchencoder.h
+++ b/native/src/seal/batchencoder.h
@@ -77,7 +77,7 @@ namespace seal
         @param[out] destination The plaintext polynomial to overwrite with the result
         @throws std::invalid_argument if values is too large
         */
-        void encode(const std::vector<std::uint64_t> &values, Plaintext &destination);
+        void encode(const std::vector<std::uint64_t> &values, Plaintext &destination) const;
 
         /**
         Creates a plaintext from a given matrix. This function "batches" a given matrix
@@ -95,7 +95,7 @@ namespace seal
         @param[out] destination The plaintext polynomial to overwrite with the result
         @throws std::invalid_argument if values is too large
         */
-        void encode(const std::vector<std::int64_t> &values, Plaintext &destination);
+        void encode(const std::vector<std::int64_t> &values, Plaintext &destination) const;
 #ifdef SEAL_USE_MSGSL
         /**
         Creates a plaintext from a given matrix. This function "batches" a given matrix
@@ -113,7 +113,7 @@ namespace seal
         @param[out] destination The plaintext polynomial to overwrite with the result
         @throws std::invalid_argument if values is too large
         */
-        void encode(gsl::span<const std::uint64_t> values, Plaintext &destination);
+        void encode(gsl::span<const std::uint64_t> values, Plaintext &destination) const;
 
         /**
         Creates a plaintext from a given matrix. This function "batches" a given matrix
@@ -131,7 +131,7 @@ namespace seal
         @param[out] destination The plaintext polynomial to overwrite with the result
         @throws std::invalid_argument if values is too large
         */
-        void encode(gsl::span<const std::int64_t> values, Plaintext &destination);
+        void encode(gsl::span<const std::int64_t> values, Plaintext &destination) const;
 #endif
         /**
         Inverse of encode. This function "unbatches" a given plaintext into a matrix
@@ -150,7 +150,7 @@ namespace seal
         */
         void decode(
             const Plaintext &plain, std::vector<std::uint64_t> &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool());
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Inverse of encode. This function "unbatches" a given plaintext into a matrix
@@ -169,7 +169,7 @@ namespace seal
         */
         void decode(
             const Plaintext &plain, std::vector<std::int64_t> &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool());
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 #ifdef SEAL_USE_MSGSL
         /**
         Inverse of encode. This function "unbatches" a given plaintext into a matrix
@@ -189,7 +189,7 @@ namespace seal
         */
         void decode(
             const Plaintext &plain, gsl::span<std::uint64_t> destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool());
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Inverse of encode. This function "unbatches" a given plaintext into a matrix
@@ -209,7 +209,7 @@ namespace seal
         */
         void decode(
             const Plaintext &plain, gsl::span<std::int64_t> destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool());
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 #endif
         /**
         Returns the number of slots.

--- a/native/src/seal/evaluator.cpp
+++ b/native/src/seal/evaluator.cpp
@@ -75,7 +75,7 @@ namespace seal
         }
     }
 
-    void Evaluator::negate_inplace(Ciphertext &encrypted)
+    void Evaluator::negate_inplace(Ciphertext &encrypted) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -100,7 +100,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::add_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2)
+    void Evaluator::add_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted1, context_) || !is_buffer_valid(encrypted1))
@@ -163,7 +163,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::add_many(const vector<Ciphertext> &encrypteds, Ciphertext &destination)
+    void Evaluator::add_many(const vector<Ciphertext> &encrypteds, Ciphertext &destination) const
     {
         if (encrypteds.empty())
         {
@@ -184,7 +184,7 @@ namespace seal
         }
     }
 
-    void Evaluator::sub_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2)
+    void Evaluator::sub_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted1, context_) || !is_buffer_valid(encrypted1))
@@ -245,7 +245,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::multiply_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)
+    void Evaluator::multiply_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted1, context_) || !is_buffer_valid(encrypted1))
@@ -284,7 +284,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::bfv_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)
+    void Evaluator::bfv_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)  const
     {
         if (encrypted1.is_ntt_form() || encrypted2.is_ntt_form())
         {
@@ -469,7 +469,7 @@ namespace seal
         encrypted1.scale() = new_scale;
     }
 
-    void Evaluator::ckks_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)
+    void Evaluator::ckks_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool) const
     {
         if (!(encrypted1.is_ntt_form() && encrypted2.is_ntt_form()))
         {
@@ -549,7 +549,7 @@ namespace seal
         encrypted1.scale() = new_scale;
     }
 
-    void Evaluator::square_inplace(Ciphertext &encrypted, MemoryPoolHandle pool)
+    void Evaluator::square_inplace(Ciphertext &encrypted, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -580,7 +580,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::bfv_square(Ciphertext &encrypted, MemoryPoolHandle pool)
+    void Evaluator::bfv_square(Ciphertext &encrypted, MemoryPoolHandle pool) const
     {
         if (encrypted.is_ntt_form())
         {
@@ -733,7 +733,7 @@ namespace seal
         encrypted.scale() = new_scale;
     }
 
-    void Evaluator::ckks_square(Ciphertext &encrypted, MemoryPoolHandle pool)
+    void Evaluator::ckks_square(Ciphertext &encrypted, MemoryPoolHandle pool) const
     {
         if (!encrypted.is_ntt_form())
         {
@@ -800,7 +800,7 @@ namespace seal
     }
 
     void Evaluator::relinearize_internal(
-        Ciphertext &encrypted, const RelinKeys &relin_keys, size_t destination_size, MemoryPoolHandle pool)
+        Ciphertext &encrypted, const RelinKeys &relin_keys, size_t destination_size, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         auto context_data_ptr = context_.get_context_data(encrypted.parms_id());
@@ -857,7 +857,7 @@ namespace seal
     }
 
     void Evaluator::mod_switch_scale_to_next(
-        const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool)
+        const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool) const
     {
         // Assuming at this point encrypted is already validated.
         auto context_data_ptr = context_.get_context_data(encrypted.parms_id());
@@ -921,7 +921,7 @@ namespace seal
         }
     }
 
-    void Evaluator::mod_switch_drop_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool)
+    void Evaluator::mod_switch_drop_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool) const
     {
         // Assuming at this point encrypted is already validated.
         auto context_data_ptr = context_.get_context_data(encrypted.parms_id());
@@ -985,7 +985,7 @@ namespace seal
         }
     }
 
-    void Evaluator::mod_switch_drop_to_next(Plaintext &plain)
+    void Evaluator::mod_switch_drop_to_next(Plaintext &plain) const
     {
         // Assuming at this point plain is already validated.
         auto context_data_ptr = context_.get_context_data(plain.parms_id());
@@ -1020,7 +1020,7 @@ namespace seal
         plain.parms_id() = next_context_data.parms_id();
     }
 
-    void Evaluator::mod_switch_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool)
+    void Evaluator::mod_switch_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1062,7 +1062,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::mod_switch_to_inplace(Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool)
+    void Evaluator::mod_switch_to_inplace(Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         auto context_data_ptr = context_.get_context_data(encrypted.parms_id());
@@ -1086,7 +1086,7 @@ namespace seal
         }
     }
 
-    void Evaluator::mod_switch_to_inplace(Plaintext &plain, parms_id_type parms_id)
+    void Evaluator::mod_switch_to_inplace(Plaintext &plain, parms_id_type parms_id) const
     {
         // Verify parameters.
         auto context_data_ptr = context_.get_context_data(plain.parms_id());
@@ -1114,7 +1114,7 @@ namespace seal
         }
     }
 
-    void Evaluator::rescale_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool)
+    void Evaluator::rescale_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1152,7 +1152,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::rescale_to_inplace(Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool)
+    void Evaluator::rescale_to_inplace(Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1206,7 +1206,7 @@ namespace seal
 
     void Evaluator::multiply_many(
         const vector<Ciphertext> &encrypteds, const RelinKeys &relin_keys, Ciphertext &destination,
-        MemoryPoolHandle pool)
+        MemoryPoolHandle pool) const
     {
         // Verify parameters.
         if (encrypteds.size() == 0)
@@ -1282,7 +1282,7 @@ namespace seal
     }
 
     void Evaluator::exponentiate_inplace(
-        Ciphertext &encrypted, uint64_t exponent, const RelinKeys &relin_keys, MemoryPoolHandle pool)
+        Ciphertext &encrypted, uint64_t exponent, const RelinKeys &relin_keys, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         auto context_data_ptr = context_.get_context_data(encrypted.parms_id());
@@ -1314,7 +1314,7 @@ namespace seal
         multiply_many(exp_vector, relin_keys, encrypted, move(pool));
     }
 
-    void Evaluator::add_plain_inplace(Ciphertext &encrypted, const Plaintext &plain)
+    void Evaluator::add_plain_inplace(Ciphertext &encrypted, const Plaintext &plain) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1388,7 +1388,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::sub_plain_inplace(Ciphertext &encrypted, const Plaintext &plain)
+    void Evaluator::sub_plain_inplace(Ciphertext &encrypted, const Plaintext &plain) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1462,7 +1462,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::multiply_plain_inplace(Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool)
+    void Evaluator::multiply_plain_inplace(Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool) const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1499,7 +1499,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::multiply_plain_normal(Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool)
+    void Evaluator::multiply_plain_normal(Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool) const
     {
         // Extract encryption parameters.
         auto &context_data = *context_.get_context_data(encrypted.parms_id());
@@ -1627,7 +1627,7 @@ namespace seal
         encrypted.scale() = new_scale;
     }
 
-    void Evaluator::multiply_plain_ntt(Ciphertext &encrypted_ntt, const Plaintext &plain_ntt)
+    void Evaluator::multiply_plain_ntt(Ciphertext &encrypted_ntt, const Plaintext &plain_ntt)  const
     {
         // Verify parameters.
         if (!plain_ntt.is_ntt_form())
@@ -1668,7 +1668,7 @@ namespace seal
         encrypted_ntt.scale() = new_scale;
     }
 
-    void Evaluator::transform_to_ntt_inplace(Plaintext &plain, parms_id_type parms_id, MemoryPoolHandle pool)
+    void Evaluator::transform_to_ntt_inplace(Plaintext &plain, parms_id_type parms_id, MemoryPoolHandle pool)  const
     {
         // Verify parameters.
         if (!is_valid_for(plain, context_))
@@ -1761,7 +1761,7 @@ namespace seal
         plain.parms_id() = parms_id;
     }
 
-    void Evaluator::transform_to_ntt_inplace(Ciphertext &encrypted)
+    void Evaluator::transform_to_ntt_inplace(Ciphertext &encrypted)  const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1809,7 +1809,7 @@ namespace seal
 #endif
     }
 
-    void Evaluator::transform_from_ntt_inplace(Ciphertext &encrypted_ntt)
+    void Evaluator::transform_from_ntt_inplace(Ciphertext &encrypted_ntt)  const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted_ntt, context_) || !is_buffer_valid(encrypted_ntt))
@@ -1857,7 +1857,7 @@ namespace seal
     }
 
     void Evaluator::apply_galois_inplace(
-        Ciphertext &encrypted, uint32_t galois_elt, const GaloisKeys &galois_keys, MemoryPoolHandle pool)
+        Ciphertext &encrypted, uint32_t galois_elt, const GaloisKeys &galois_keys, MemoryPoolHandle pool)  const
     {
         // Verify parameters.
         if (!is_metadata_valid_for(encrypted, context_) || !is_buffer_valid(encrypted))
@@ -1961,7 +1961,7 @@ namespace seal
     }
 
     void Evaluator::rotate_internal(
-        Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys, MemoryPoolHandle pool)
+        Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys, MemoryPoolHandle pool)  const
     {
         auto context_data_ptr = context_.get_context_data(encrypted.parms_id());
         if (!context_data_ptr)
@@ -2019,7 +2019,7 @@ namespace seal
 
     void Evaluator::switch_key_inplace(
         Ciphertext &encrypted, ConstRNSIter target_iter, const KSwitchKeys &kswitch_keys, size_t kswitch_keys_index,
-        MemoryPoolHandle pool)
+        MemoryPoolHandle pool)  const
     {
         auto parms_id = encrypted.parms_id();
         auto &context_data = *context_.get_context_data(parms_id);

--- a/native/src/seal/evaluator.h
+++ b/native/src/seal/evaluator.h
@@ -89,7 +89,7 @@ namespace seal
         @throws std::invalid_argument if encrypted is not valid for the encryption
         parameters
         */
-        void negate_inplace(Ciphertext &encrypted);
+        void negate_inplace(Ciphertext &encrypted)  const;
 
         /**
         Negates a ciphertext and stores the result in the destination parameter.
@@ -99,7 +99,7 @@ namespace seal
         @throws std::invalid_argument if encrypted is not valid for the encryption parameters
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void negate(const Ciphertext &encrypted, Ciphertext &destination)
+        inline void negate(const Ciphertext &encrypted, Ciphertext &destination)  const
         {
             destination = encrypted;
             negate_inplace(destination);
@@ -115,7 +115,7 @@ namespace seal
         @throws std::invalid_argument if encrypted1 and encrypted2 are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        void add_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2);
+        void add_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2)  const;
 
         /**
         Adds two ciphertexts. This function adds together encrypted1 and encrypted2 and stores the result in the
@@ -129,7 +129,7 @@ namespace seal
         @throws std::invalid_argument if encrypted1 and encrypted2 are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void add(const Ciphertext &encrypted1, const Ciphertext &encrypted2, Ciphertext &destination)
+        inline void add(const Ciphertext &encrypted1, const Ciphertext &encrypted2, Ciphertext &destination) const
         {
             if (&encrypted2 == &destination)
             {
@@ -155,7 +155,7 @@ namespace seal
         @throws std::invalid_argument if destination is one of encrypteds
         @throws std::logic_error if result ciphertext is transparent
         */
-        void add_many(const std::vector<Ciphertext> &encrypteds, Ciphertext &destination);
+        void add_many(const std::vector<Ciphertext> &encrypteds, Ciphertext &destination) const;
 
         /**
         Subtracts two ciphertexts. This function computes the difference of encrypted1 and encrypted2, and stores the
@@ -168,7 +168,7 @@ namespace seal
         @throws std::invalid_argument if encrypted1 and encrypted2 are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        void sub_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2);
+        void sub_inplace(Ciphertext &encrypted1, const Ciphertext &encrypted2) const;
 
         /**
         Subtracts two ciphertexts. This function computes the difference of encrypted1 and encrypted2 and stores the
@@ -182,7 +182,7 @@ namespace seal
         @throws std::invalid_argument if encrypted1 and encrypted2 are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void sub(const Ciphertext &encrypted1, const Ciphertext &encrypted2, Ciphertext &destination)
+        inline void sub(const Ciphertext &encrypted1, const Ciphertext &encrypted2, Ciphertext &destination) const
         {
             if (&encrypted2 == &destination)
             {
@@ -212,7 +212,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         void multiply_inplace(
-            Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool = MemoryManager::GetPool());
+            Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Multiplies two ciphertexts. This functions computes the product of encrypted1 and encrypted2 and stores the
@@ -232,7 +232,7 @@ namespace seal
         */
         inline void multiply(
             const Ciphertext &encrypted1, const Ciphertext &encrypted2, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             if (&encrypted2 == &destination)
             {
@@ -257,7 +257,7 @@ namespace seal
         @throws std::invalid_argument if pool is uninitialized
         @throws std::logic_error if result ciphertext is transparent
         */
-        void square_inplace(Ciphertext &encrypted, MemoryPoolHandle pool = MemoryManager::GetPool());
+        void square_inplace(Ciphertext &encrypted, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Squares a ciphertext. This functions computes the square of encrypted and stores the result in the destination
@@ -274,7 +274,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         inline void square(
-            const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool())
+            const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             square_inplace(destination, std::move(pool));
@@ -297,7 +297,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         inline void relinearize_inplace(
-            Ciphertext &encrypted, const RelinKeys &relin_keys, MemoryPoolHandle pool = MemoryManager::GetPool())
+            Ciphertext &encrypted, const RelinKeys &relin_keys, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             relinearize_internal(encrypted, relin_keys, 2, std::move(pool));
         }
@@ -322,7 +322,7 @@ namespace seal
         */
         inline void relinearize(
             const Ciphertext &encrypted, const RelinKeys &relin_keys, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             relinearize_inplace(destination, relin_keys, std::move(pool));
@@ -344,7 +344,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         void mod_switch_to_next(
-            const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool());
+            const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Given a ciphertext encrypted modulo q_1...q_k, this function switches the modulus down to q_1...q_{k-1}. Dynamic
@@ -359,7 +359,7 @@ namespace seal
         @throws std::invalid_argument if pool is uninitialized
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void mod_switch_to_next_inplace(Ciphertext &encrypted, MemoryPoolHandle pool = MemoryManager::GetPool())
+        inline void mod_switch_to_next_inplace(Ciphertext &encrypted, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             mod_switch_to_next(encrypted, encrypted, std::move(pool));
         }
@@ -373,7 +373,7 @@ namespace seal
         @throws std::invalid_argument if plain is already at lowest level
         @throws std::invalid_argument if the scale is too large for the new encryption parameters
         */
-        inline void mod_switch_to_next_inplace(Plaintext &plain)
+        inline void mod_switch_to_next_inplace(Plaintext &plain) const
         {
             // Verify parameters.
             if (!is_valid_for(plain, context_))
@@ -396,7 +396,7 @@ namespace seal
         @throws std::invalid_argument if the scale is too large for the new encryption parameters
         @throws std::invalid_argument if pool is uninitialized
         */
-        inline void mod_switch_to_next(const Plaintext &plain, Plaintext &destination)
+        inline void mod_switch_to_next(const Plaintext &plain, Plaintext &destination) const
         {
             destination = plain;
             mod_switch_to_next_inplace(destination);
@@ -420,7 +420,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         void mod_switch_to_inplace(
-            Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool = MemoryManager::GetPool());
+            Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Given a ciphertext encrypted modulo q_1...q_k, this function switches the modulus down until the parameters
@@ -442,7 +442,7 @@ namespace seal
         */
         inline void mod_switch_to(
             const Ciphertext &encrypted, parms_id_type parms_id, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             mod_switch_to_inplace(destination, parms_id, std::move(pool));
@@ -461,7 +461,7 @@ namespace seal
         corresponding to parms_id
         @throws std::invalid_argument if the scale is too large for the new encryption parameters
         */
-        void mod_switch_to_inplace(Plaintext &plain, parms_id_type parms_id);
+        void mod_switch_to_inplace(Plaintext &plain, parms_id_type parms_id) const;
 
         /**
         Given an NTT transformed plaintext modulo q_1...q_k, this function switches the modulus down until the
@@ -477,7 +477,7 @@ namespace seal
         corresponding to parms_id
         @throws std::invalid_argument if the scale is too large for the new encryption parameters
         */
-        inline void mod_switch_to(const Plaintext &plain, parms_id_type parms_id, Plaintext &destination)
+        inline void mod_switch_to(const Plaintext &plain, parms_id_type parms_id, Plaintext &destination) const
         {
             destination = plain;
             mod_switch_to_inplace(destination, parms_id);
@@ -499,7 +499,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         void rescale_to_next(
-            const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool());
+            const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Given a ciphertext encrypted modulo q_1...q_k, this function switches the modulus down to q_1...q_{k-1} and
@@ -515,7 +515,7 @@ namespace seal
         @throws std::invalid_argument if pool is uninitialized
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void rescale_to_next_inplace(Ciphertext &encrypted, MemoryPoolHandle pool = MemoryManager::GetPool())
+        inline void rescale_to_next_inplace(Ciphertext &encrypted, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             rescale_to_next(encrypted, encrypted, std::move(pool));
         }
@@ -538,7 +538,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         void rescale_to_inplace(
-            Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool = MemoryManager::GetPool());
+            Ciphertext &encrypted, parms_id_type parms_id, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Given a ciphertext encrypted modulo q_1...q_k, this function switches the modulus down until the parameters
@@ -561,7 +561,7 @@ namespace seal
         */
         inline void rescale_to(
             const Ciphertext &encrypted, parms_id_type parms_id, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             rescale_to_inplace(destination, parms_id, std::move(pool));
@@ -590,7 +590,7 @@ namespace seal
         */
         void multiply_many(
             const std::vector<Ciphertext> &encrypteds, const RelinKeys &relin_keys, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool());
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Exponentiates a ciphertext. This functions raises encrypted to a power. Dynamic memory allocations in the
@@ -614,7 +614,7 @@ namespace seal
         */
         void exponentiate_inplace(
             Ciphertext &encrypted, std::uint64_t exponent, const RelinKeys &relin_keys,
-            MemoryPoolHandle pool = MemoryManager::GetPool());
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Exponentiates a ciphertext. This functions raises encrypted to a power and stores the result in the destination
@@ -640,7 +640,7 @@ namespace seal
         */
         inline void exponentiate(
             const Ciphertext &encrypted, std::uint64_t exponent, const RelinKeys &relin_keys, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             exponentiate_inplace(destination, exponent, relin_keys, std::move(pool));
@@ -656,7 +656,7 @@ namespace seal
         @throws std::invalid_argument if encrypted and plain are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        void add_plain_inplace(Ciphertext &encrypted, const Plaintext &plain);
+        void add_plain_inplace(Ciphertext &encrypted, const Plaintext &plain) const;
 
         /**
         Adds a ciphertext and a plaintext. This function adds a ciphertext and a plaintext and stores the result in the
@@ -671,7 +671,7 @@ namespace seal
         @throws std::invalid_argument if encrypted and plain are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void add_plain(const Ciphertext &encrypted, const Plaintext &plain, Ciphertext &destination)
+        inline void add_plain(const Ciphertext &encrypted, const Plaintext &plain, Ciphertext &destination) const
         {
             destination = encrypted;
             add_plain_inplace(destination, plain);
@@ -687,7 +687,7 @@ namespace seal
         @throws std::invalid_argument if encrypted and plain are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        void sub_plain_inplace(Ciphertext &encrypted, const Plaintext &plain);
+        void sub_plain_inplace(Ciphertext &encrypted, const Plaintext &plain) const;
 
         /**
         Subtracts a plaintext from a ciphertext. This function subtracts a plaintext from a ciphertext and stores the
@@ -701,7 +701,7 @@ namespace seal
         @throws std::invalid_argument if encrypted and plain are at different level or scale
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void sub_plain(const Ciphertext &encrypted, const Plaintext &plain, Ciphertext &destination)
+        inline void sub_plain(const Ciphertext &encrypted, const Plaintext &plain, Ciphertext &destination) const
         {
             destination = encrypted;
             sub_plain_inplace(destination, plain);
@@ -721,7 +721,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         void multiply_plain_inplace(
-            Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool = MemoryManager::GetPool());
+            Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Multiplies a ciphertext with a plaintext. This function multiplies a ciphertext with a plaintext and stores the
@@ -740,7 +740,7 @@ namespace seal
         */
         inline void multiply_plain(
             const Ciphertext &encrypted, const Plaintext &plain, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             multiply_plain_inplace(destination, plain, std::move(pool));
@@ -764,7 +764,7 @@ namespace seal
         @throws std::invalid_argument if pool is uninitialized
         */
         void transform_to_ntt_inplace(
-            Plaintext &plain, parms_id_type parms_id, MemoryPoolHandle pool = MemoryManager::GetPool());
+            Plaintext &plain, parms_id_type parms_id, MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Transforms a plaintext to NTT domain. This functions applies the Number Theoretic Transform to a plaintext by
@@ -787,7 +787,7 @@ namespace seal
         */
         inline void transform_to_ntt(
             const Plaintext &plain, parms_id_type parms_id, Plaintext &destination_ntt,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination_ntt = plain;
             transform_to_ntt_inplace(destination_ntt, parms_id, std::move(pool));
@@ -803,7 +803,7 @@ namespace seal
         @throws std::invalid_argument if encrypted is already in NTT form
         @throws std::logic_error if result ciphertext is transparent
         */
-        void transform_to_ntt_inplace(Ciphertext &encrypted);
+        void transform_to_ntt_inplace(Ciphertext &encrypted) const;
 
         /**
         Transforms a ciphertext to NTT domain. This functions applies David Harvey's Number Theoretic Transform
@@ -816,7 +816,7 @@ namespace seal
         @throws std::invalid_argument if encrypted is already in NTT form
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void transform_to_ntt(const Ciphertext &encrypted, Ciphertext &destination_ntt)
+        inline void transform_to_ntt(const Ciphertext &encrypted, Ciphertext &destination_ntt) const
         {
             destination_ntt = encrypted;
             transform_to_ntt_inplace(destination_ntt);
@@ -832,7 +832,7 @@ namespace seal
         @throws std::invalid_argument if encrypted_ntt is not in NTT form
         @throws std::logic_error if result ciphertext is transparent
         */
-        void transform_from_ntt_inplace(Ciphertext &encrypted_ntt);
+        void transform_from_ntt_inplace(Ciphertext &encrypted_ntt) const;
 
         /**
         Transforms a ciphertext back from NTT domain. This functions applies the inverse of David Harvey's Number
@@ -846,7 +846,7 @@ namespace seal
         @throws std::invalid_argument if encrypted_ntt is not in NTT form
         @throws std::logic_error if result ciphertext is transparent
         */
-        inline void transform_from_ntt(const Ciphertext &encrypted_ntt, Ciphertext &destination)
+        inline void transform_from_ntt(const Ciphertext &encrypted_ntt, Ciphertext &destination) const
         {
             destination = encrypted_ntt;
             transform_from_ntt_inplace(destination);
@@ -882,7 +882,7 @@ namespace seal
         */
         void apply_galois_inplace(
             Ciphertext &encrypted, std::uint32_t galois_elt, const GaloisKeys &galois_keys,
-            MemoryPoolHandle pool = MemoryManager::GetPool());
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const;
 
         /**
         Applies a Galois automorphism to a ciphertext and writes the result to the destination parameter. To evaluate
@@ -915,7 +915,7 @@ namespace seal
         */
         inline void apply_galois(
             const Ciphertext &encrypted, std::uint32_t galois_elt, const GaloisKeys &galois_keys,
-            Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool())
+            Ciphertext &destination, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             apply_galois_inplace(destination, galois_elt, galois_keys, std::move(pool));
@@ -948,7 +948,7 @@ namespace seal
         */
         inline void rotate_rows_inplace(
             Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             if (context_.key_context_data()->parms().scheme() != scheme_type::bfv)
             {
@@ -985,7 +985,7 @@ namespace seal
         */
         inline void rotate_rows(
             const Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             rotate_rows_inplace(destination, steps, galois_keys, std::move(pool));
@@ -1015,7 +1015,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         inline void rotate_columns_inplace(
-            Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool = MemoryManager::GetPool())
+            Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             if (context_.key_context_data()->parms().scheme() != scheme_type::bfv)
             {
@@ -1050,7 +1050,7 @@ namespace seal
         */
         inline void rotate_columns(
             const Ciphertext &encrypted, const GaloisKeys &galois_keys, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             rotate_columns_inplace(destination, galois_keys, std::move(pool));
@@ -1082,7 +1082,7 @@ namespace seal
         */
         inline void rotate_vector_inplace(
             Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             if (context_.key_context_data()->parms().scheme() != scheme_type::ckks)
             {
@@ -1118,7 +1118,7 @@ namespace seal
         */
         inline void rotate_vector(
             const Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             rotate_vector_inplace(destination, steps, galois_keys, std::move(pool));
@@ -1146,7 +1146,7 @@ namespace seal
         @throws std::logic_error if result ciphertext is transparent
         */
         inline void complex_conjugate_inplace(
-            Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool = MemoryManager::GetPool())
+            Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             if (context_.key_context_data()->parms().scheme() != scheme_type::ckks)
             {
@@ -1178,7 +1178,7 @@ namespace seal
         */
         inline void complex_conjugate(
             const Ciphertext &encrypted, const GaloisKeys &galois_keys, Ciphertext &destination,
-            MemoryPoolHandle pool = MemoryManager::GetPool())
+            MemoryPoolHandle pool = MemoryManager::GetPool()) const
         {
             destination = encrypted;
             complex_conjugate_inplace(destination, galois_keys, std::move(pool));
@@ -1198,26 +1198,26 @@ namespace seal
 
         Evaluator &operator=(Evaluator &&assign) = delete;
 
-        void bfv_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool);
+        void bfv_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)  const;
 
-        void ckks_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool);
+        void ckks_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)  const;
 
-        void bfv_square(Ciphertext &encrypted, MemoryPoolHandle pool);
+        void bfv_square(Ciphertext &encrypted, MemoryPoolHandle pool) const;
 
-        void ckks_square(Ciphertext &encrypted, MemoryPoolHandle pool);
+        void ckks_square(Ciphertext &encrypted, MemoryPoolHandle pool) const;
 
         void relinearize_internal(
-            Ciphertext &encrypted, const RelinKeys &relin_keys, std::size_t destination_size, MemoryPoolHandle pool);
+            Ciphertext &encrypted, const RelinKeys &relin_keys, std::size_t destination_size, MemoryPoolHandle pool) const;
 
-        void mod_switch_scale_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool);
+        void mod_switch_scale_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool) const;
 
-        void mod_switch_drop_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool);
+        void mod_switch_drop_to_next(const Ciphertext &encrypted, Ciphertext &destination, MemoryPoolHandle pool) const;
 
-        void mod_switch_drop_to_next(Plaintext &plain);
+        void mod_switch_drop_to_next(Plaintext &plain) const;
 
-        void rotate_internal(Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys, MemoryPoolHandle pool);
+        void rotate_internal(Ciphertext &encrypted, int steps, const GaloisKeys &galois_keys, MemoryPoolHandle pool) const;
 
-        inline void conjugate_internal(Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool)
+        inline void conjugate_internal(Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool) const
         {
             // Verify parameters.
             auto context_data_ptr = context_.get_context_data(encrypted.parms_id());
@@ -1241,11 +1241,11 @@ namespace seal
 
         void switch_key_inplace(
             Ciphertext &encrypted, util::ConstRNSIter target_iter, const KSwitchKeys &kswitch_keys,
-            std::size_t key_index, MemoryPoolHandle pool = MemoryManager::GetPool());
+            std::size_t key_index, MemoryPoolHandle pool = MemoryManager::GetPool())  const;
 
-        void multiply_plain_normal(Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool);
+        void multiply_plain_normal(Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool) const;
 
-        void multiply_plain_ntt(Ciphertext &encrypted_ntt, const Plaintext &plain_ntt);
+        void multiply_plain_ntt(Ciphertext &encrypted_ntt, const Plaintext &plain_ntt) const;
 
         void populate_Zmstar_to_generator();
 


### PR DESCRIPTION
Addressing #333 

This adds const qualifiers to functions like `BatchEncoder::encode` or `Evaluator::add` that modify their operands but not the actual Encoder/Evaluator object. 

This helps quite a bit with writing "neat" code against SEAL (less for individual applications, more for frameworks and compilers) 