### PR TITLE
Optimize CKKS square

### DIFF
--- a/native/src/seal/evaluator.cpp
+++ b/native/src/seal/evaluator.cpp
@@ -847,21 +847,16 @@ namespace seal
         // Set up iterators for input ciphertext
         auto encrypted_iter = iter(encrypted);
 
-        // Allocate temporary space for the result
-        SEAL_ALLOCATE_ZERO_GET_POLY_ITER(temp, dest_size, coeff_count, coeff_modulus_size, pool);
-
-        // Compute c0^2
-        dyadic_product_coeffmod(encrypted_iter[0], encrypted_iter[0], coeff_modulus_size, coeff_modulus, temp[0]);
+        // Compute c1^2
+        dyadic_product_coeffmod(
+            encrypted_iter[1], encrypted_iter[1], coeff_modulus_size, coeff_modulus, encrypted_iter[2]);
 
         // Compute 2*c0*c1
-        dyadic_product_coeffmod(encrypted_iter[0], encrypted_iter[1], coeff_modulus_size, coeff_modulus, temp[1]);
-        add_poly_coeffmod(temp[1], temp[1], coeff_modulus_size, coeff_modulus, temp[1]);
+        dyadic_product_coeffmod(encrypted_iter[0], encrypted_iter[1], coeff_modulus_size, coeff_modulus, encrypted_iter[1]);
+        add_poly_coeffmod(encrypted_iter[1], encrypted_iter[1], coeff_modulus_size, coeff_modulus, encrypted_iter[1]);
 
-        // Compute c1^2
-        dyadic_product_coeffmod(encrypted_iter[1], encrypted_iter[1], coeff_modulus_size, coeff_modulus, temp[2]);
-
-        // Set the final result
-        set_poly_array(temp, dest_size, coeff_count, coeff_modulus_size, encrypted.data());
+       // Compute c0^2
+        dyadic_product_coeffmod(encrypted_iter[0], encrypted_iter[0], coeff_modulus_size, coeff_modulus, encrypted_iter[0]);
 
         // Set the scale
         encrypted.scale() = new_scale;


### PR DESCRIPTION
Optimizes CKKS square by avoiding unnecessary allocation / copy.

On ICX with clang-12, running `sealbench` CKKS EvaluateSquare for 1000 iterations yields:

| N     | HEXL | Time before (us) | Time after (us) | Speedup |
|------ |------|------------------|-----------------|---------|
| 1024  | OFF  |   12.3           |     11.7        | 1.05x   |
| 1024  | ON   |   2.39           |     1.68        | 1.42x   |
| 2048  | OFF  |   24.4           |     22.5        | 1.08x   |
| 2048  | ON   |   8.68           |     6.52        | 1.33x   |
| 4096  | OFF  |   107            |     89.3        | 1.22x   |
| 4096  | ON   |   38.4           |     31.1        | 1.23x   |
| 8192  | OFF  |   429            |     375         | 1.14x   |
| 8192  | ON   |   183            |     106         | 1.75x   |
| 16384 | OFF  |   1878           |     1520        | 1.23x   |
| 16384 | ON   |   774            |     401         | 1.93x   |
| 32768 | OFF  |   6972           |     5798        | 1.20x   |
| 32768 | ON   |   3205           |     1990        | 1.61x   |

I didn't see significant additional speedup  with a tiling approach similar to https://github.com/microsoft/SEAL/pull/346.
In case you'd like to try it out, I've pasted the code for a tiled version of this implementation below. 

```
       // Prepare destination
        encrypted.resize(context_, context_data.parms_id(), dest_size);
        // Set up iterators for input ciphertext
        // auto encrypted_iter = iter(encrypted);

        size_t tile_size = min<size_t>(coeff_count, size_t(1024));
        size_t num_tiles = coeff_count / tile_size;
#ifdef SEAL_DEBUG
        if (coeff_count % tile_size != 0)
        {
            throw invalid_argument("tile_size does not divide coeff_count");
        }
#endif

        // Set up iterators for input ciphertexts
        PolyIter encrypted_iter = iter(encrypted);

        // Semantic misuse of RNSIter; each is really pointing to the data for each RNS factor in sequence
        RNSIter encrypted1_0_iter(*encrypted_iter[0], tile_size);
        RNSIter encrypted1_1_iter(*encrypted_iter[1], tile_size);
        RNSIter encrypted1_2_iter(*encrypted_iter[2], tile_size);

        // Computes the output tile_size coefficients at a time
        // Given input tuple of polynomials x = (x[0], x[1], x[2]), computes
        // x = (x[0] * x[0], 2 * x[0] * x[1] , x[1] * x[1])
        // with appropriate modular reduction
        SEAL_ITERATE(coeff_modulus, coeff_modulus_size, [&](auto I) {
            SEAL_ITERATE(iter(size_t(0)), num_tiles, [&](auto J) {
                // Compute third output polynomial, overwriting input
                // x[2] = x[1] * x[1]
                dyadic_product_coeffmod(encrypted1_1_iter[0], encrypted1_1_iter[0], tile_size, I, encrypted1_2_iter[0]);

                // Compute second output polynomial, overwriting input
                // x[1] = x[1] * x[0]
                dyadic_product_coeffmod(encrypted1_1_iter[0], encrypted1_0_iter[0], tile_size, I, encrypted1_1_iter[0]);
                // x[1] += x[1]
                add_poly_coeffmod(encrypted1_1_iter[0], encrypted1_1_iter[0], tile_size, I, encrypted1_1_iter[0]);

                // Compute first output polynomial, overwriting input
                // x[0] = x[0] * x[0]
                dyadic_product_coeffmod(encrypted1_0_iter[0], encrypted1_0_iter[0], tile_size, I, encrypted1_0_iter[0]);

                // Manually increment iterators
                ++encrypted1_0_iter;
                ++encrypted1_1_iter;
                ++encrypted1_2_iter;
            });
        });
```

