### PR TITLE
Fboemer/faster decrypt

### DIFF
--- a/native/src/seal/evaluator.cpp
+++ b/native/src/seal/evaluator.cpp
@@ -617,7 +617,7 @@ namespace seal
         encrypted1.scale() = new_scale;
     }
 
-    void Evaluator::bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool)
+    void Evaluator::bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool) const
     {
         if (encrypted1.is_ntt_form() || encrypted2.is_ntt_form())
         {

--- a/native/src/seal/evaluator.h
+++ b/native/src/seal/evaluator.h
@@ -1017,7 +1017,7 @@ namespace seal
         */
         inline void rotate_columns_inplace(
             Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool = MemoryManager::GetPool()) const
-        {   
+        {
             auto scheme = context_.key_context_data()->parms().scheme();
             if (scheme != scheme_type::bfv && scheme != scheme_type::bgv)
             {
@@ -1204,7 +1204,7 @@ namespace seal
 
         void ckks_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)  const;
 
-        void bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool);
+        void bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool) const;
 
         void bfv_square(Ciphertext &encrypted, MemoryPoolHandle pool) const;
 


### PR DESCRIPTION
Optimize CKKS and (to a lesser degree) BFV Decrypt. Also fixes BGV compilation error. 

On ICX with clang-12:
* with HEXL=ON, CKKS decrypt shows:

| N     |  Time before (us) | Time after (us) | Speedup |
|------ |-------------------|-----------------|---------|
| 1024  |    1.70           |     1.42        | 1.20x   |
| 2048  |    4.09           |     3.69        | 1.10x   |
| 4096  |    12.5           |     8.56        | 1.46x   |
| 8192  |    76.1           |     60.4        | 1.26x   |
| 16384 |    381           |     216          | 1.76x   |

* with HEXL=OFF, CKKS decrypt shows:

| N     |  Time before (us) | Time after (us) | Speedup |
|------ |-------------------|-----------------|---------|
| 1024  |    6.16           |     5.29        | 1.16x   |
| 2048  |    11.9           |     10.1        | 1.18x   |
| 4096  |    48.1           |     39.9        | 1.20x   |
| 8192  |    189           |     156          | 1.21x   |
| 16384 |    805            |     635         | 1.26x   |

* with HEXL=ON, BFV decrypt shows:

| N     |  Time before (us) | Time after (us) | Speedup |
|------ |-------------------|-----------------|---------|
| 1024  |    27.8           |     26.6        | 1.04x   |
| 2048  |    62.0           |     61.6        | 1.01x   |
| 4096  |    135            |     136         | 0.99x   |
| 8192  |    474            |     451         | 1.05x   |
| 16384 |    1692           |     1561        | 1.08x   |