### PR TITLE
Faster benchmarks

### DIFF
--- a/native/bench/bench.cpp
+++ b/native/bench/bench.cpp
@@ -22,8 +22,7 @@ namespace sealbench
         (string("n=") + to_string(n) + string(" / log(q)=") + to_string(log_q) + string(" / " #category " / " #name)) \
             .c_str(),                                                                                                 \
         [=](State &st) { func(st, __VA_ARGS__); })                                                                    \
-        ->Unit(benchmark::kMicrosecond)                                                                               \
-        ->Iterations(10);
+        ->Unit(benchmark::kMicrosecond)
 
     void register_bm_family(
         const pair<size_t, vector<Modulus>> &parms, unordered_map<EncryptionParameters, shared_ptr<BMEnv>> &bm_env_map)
@@ -68,11 +67,11 @@ namespace sealbench
         SEAL_BENCHMARK_REGISTER(BFV, n, log_q, EvaluateSquare, bm_bfv_square, bm_env_bfv);
         if (bm_env_bfv->context().first_context_data()->parms().coeff_modulus().size() > 1)
         {
-            SEAL_BENCHMARK_REGISTER(BFV, n, log_q, EvaluateModSwitchInplace, bm_bfv_modswitch_inplace, bm_env_bfv);
+            SEAL_BENCHMARK_REGISTER(BFV, n, log_q, EvaluateModSwitch, bm_bfv_modswitch, bm_env_bfv);
         }
         if (bm_env_bfv->context().using_keyswitching())
         {
-            SEAL_BENCHMARK_REGISTER(BFV, n, log_q, EvaluateRelinInplace, bm_bfv_relin_inplace, bm_env_bfv);
+            SEAL_BENCHMARK_REGISTER(BFV, n, log_q, EvaluateRelin, bm_bfv_relin, bm_env_bfv);
             SEAL_BENCHMARK_REGISTER(BFV, n, log_q, EvaluateRotateRows, bm_bfv_rotate_rows, bm_env_bfv);
             SEAL_BENCHMARK_REGISTER(BFV, n, log_q, EvaluateRotateCols, bm_bfv_rotate_cols, bm_env_bfv);
         }
@@ -89,11 +88,11 @@ namespace sealbench
         SEAL_BENCHMARK_REGISTER(CKKS, n, log_q, EvaluateSquare, bm_ckks_square, bm_env_ckks);
         if (bm_env_bfv->context().first_context_data()->parms().coeff_modulus().size() > 1)
         {
-            SEAL_BENCHMARK_REGISTER(CKKS, n, log_q, EvaluateRescaleInplace, bm_ckks_rescale_inplace, bm_env_ckks);
+            SEAL_BENCHMARK_REGISTER(CKKS, n, log_q, EvaluateRescale, bm_ckks_rescale, bm_env_ckks);
         }
         if (bm_env_bfv->context().using_keyswitching())
         {
-            SEAL_BENCHMARK_REGISTER(CKKS, n, log_q, EvaluateRelinInplace, bm_ckks_relin_inplace, bm_env_ckks);
+            SEAL_BENCHMARK_REGISTER(CKKS, n, log_q, EvaluateRelin, bm_ckks_relin, bm_env_ckks);
             SEAL_BENCHMARK_REGISTER(CKKS, n, log_q, EvaluateRotate, bm_ckks_rotate, bm_env_ckks);
         }
     }

--- a/native/bench/bench.h
+++ b/native/bench/bench.h
@@ -353,8 +353,8 @@ namespace sealbench
     void bm_bfv_mul_ct(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
     void bm_bfv_mul_pt(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
     void bm_bfv_square(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
-    void bm_bfv_modswitch_inplace(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
-    void bm_bfv_relin_inplace(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
+    void bm_bfv_modswitch(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
+    void bm_bfv_relin(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
     void bm_bfv_rotate_rows(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
     void bm_bfv_rotate_cols(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
 
@@ -369,7 +369,7 @@ namespace sealbench
     void bm_ckks_mul_ct(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
     void bm_ckks_mul_pt(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
     void bm_ckks_square(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
-    void bm_ckks_rescale_inplace(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
-    void bm_ckks_relin_inplace(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
+    void bm_ckks_rescale(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
+    void bm_ckks_relin(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
     void bm_ckks_rotate(benchmark::State &state, std::shared_ptr<BMEnv> bm_env);
 } // namespace sealbench

--- a/native/bench/bfv.cpp
+++ b/native/bench/bfv.cpp
@@ -18,42 +18,33 @@ namespace sealbench
 {
     void bm_bfv_encrypt_secret(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_pt_bfv(pt);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_pt_bfv(pt);
-
-            state.ResumeTiming();
             bm_env->encryptor()->encrypt_symmetric(pt, ct[2]);
         }
     }
 
     void bm_bfv_encrypt_public(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_pt_bfv(pt);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_pt_bfv(pt);
-
-            state.ResumeTiming();
             bm_env->encryptor()->encrypt(pt, ct[2]);
         }
     }
 
     void bm_bfv_decrypt(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_ct_bfv(ct[0]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-
-            state.ResumeTiming();
             bm_env->decryptor()->decrypt(ct[0], pt);
         }
     }
@@ -61,13 +52,10 @@ namespace sealbench
     void bm_bfv_encode_batch(State &state, shared_ptr<BMEnv> bm_env)
     {
         vector<uint64_t> &msg = bm_env->msg_uint64();
-        Plaintext &pt = bm_env->pt()[0];
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_message_uint64(msg);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_message_uint64(msg);
-
-            state.ResumeTiming();
             bm_env->batch_encoder()->encode(msg, pt);
         }
     }
@@ -75,138 +63,109 @@ namespace sealbench
     void bm_bfv_decode_batch(State &state, shared_ptr<BMEnv> bm_env)
     {
         vector<uint64_t> &msg = bm_env->msg_uint64();
-        Plaintext &pt = bm_env->pt()[0];
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_pt_bfv(pt);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_pt_bfv(pt);
-
-            state.ResumeTiming();
             bm_env->batch_encoder()->decode(pt, msg);
         }
     }
 
     void bm_bfv_add_ct(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_bfv(ct[0]);
+        bm_env->randomize_ct_bfv(ct[1]);
+        Ciphertext res;
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-            bm_env->randomize_ct_bfv(ct[1]);
-            state.ResumeTiming();
-            Ciphertext res;
             bm_env->evaluator()->add(ct[0], ct[1], res);
         }
     }
 
     void bm_bfv_add_pt(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_ct_bfv(ct[0]);
+        bm_env->randomize_pt_bfv(pt);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-            bm_env->randomize_pt_bfv(pt);
-
-            state.ResumeTiming();
             bm_env->evaluator()->add_plain(ct[0], pt, ct[2]);
         }
     }
 
     void bm_bfv_mul_ct(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_bfv(ct[0]);
+        bm_env->randomize_ct_bfv(ct[1]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-            bm_env->randomize_ct_bfv(ct[1]);
-
-            state.ResumeTiming();
             bm_env->evaluator()->multiply(ct[0], ct[1], ct[2]);
         }
     }
 
     void bm_bfv_mul_pt(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_ct_bfv(ct[0]);
+        bm_env->randomize_pt_bfv(pt);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-            bm_env->randomize_pt_bfv(pt);
-
-            state.ResumeTiming();
             bm_env->evaluator()->multiply_plain(ct[0], pt, ct[2]);
         }
     }
 
     void bm_bfv_square(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_bfv(ct[0]);
+        bm_env->randomize_ct_bfv(ct[1]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-            bm_env->randomize_ct_bfv(ct[1]);
-
-            state.ResumeTiming();
             bm_env->evaluator()->square(ct[0], ct[2]);
         }
     }
 
-    void bm_bfv_modswitch_inplace(State &state, shared_ptr<BMEnv> bm_env)
+    void bm_bfv_modswitch(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_bfv(ct[0]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-
-            state.ResumeTiming();
-            bm_env->evaluator()->mod_switch_to_next_inplace(ct[0]);
+            bm_env->evaluator()->mod_switch_to_next(ct[0], ct[1]);
         }
     }
 
-    void bm_bfv_relin_inplace(State &state, shared_ptr<BMEnv> bm_env)
+    void bm_bfv_relin(State &state, shared_ptr<BMEnv> bm_env)
     {
-        Ciphertext ct;
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_bfv(ct[0]);
+        ct[0].resize(bm_env->context(), size_t(3));
         for (auto _ : state)
         {
-            state.PauseTiming();
-            ct.resize(bm_env->context(), size_t(3));
-            bm_env->randomize_ct_bfv(ct);
-
-            state.ResumeTiming();
-            bm_env->evaluator()->relinearize_inplace(ct, bm_env->rlk());
+            bm_env->evaluator()->relinearize(ct[0], bm_env->rlk(), ct[1]);
         }
     }
 
     void bm_bfv_rotate_rows(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_bfv(ct[0]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-
-            state.ResumeTiming();
             bm_env->evaluator()->rotate_rows(ct[0], 1, bm_env->glk(), ct[2]);
         }
     }
 
     void bm_bfv_rotate_cols(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_bfv(ct[0]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_bfv(ct[0]);
-
-            state.ResumeTiming();
             bm_env->evaluator()->rotate_columns(ct[0], bm_env->glk(), ct[2]);
         }
     }

--- a/native/bench/ckks.cpp
+++ b/native/bench/ckks.cpp
@@ -18,201 +18,164 @@ namespace sealbench
 {
     void bm_ckks_encrypt_secret(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_pt_ckks(pt);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_pt_ckks(pt);
-
-            state.ResumeTiming();
             bm_env->encryptor()->encrypt_symmetric(pt, ct[2]);
         }
     }
 
     void bm_ckks_encrypt_public(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_pt_ckks(pt);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_pt_ckks(pt);
-
-            state.ResumeTiming();
             bm_env->encryptor()->encrypt(pt, ct[2]);
         }
     }
 
     void bm_ckks_decrypt(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_ct_ckks(ct[0]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-
-            state.ResumeTiming();
             bm_env->decryptor()->decrypt(ct[0], pt);
         }
     }
 
     void bm_ckks_encode_double(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<double> &msg = bm_env->msg_double();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<double> msg = bm_env->msg_double();
+        bm_env->randomize_message_double(msg);
+        Plaintext pt = bm_env->pt()[0];
         parms_id_type parms_id = bm_env->context().first_parms_id();
         double scale = bm_env->safe_scale();
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_message_double(msg);
-
-            state.ResumeTiming();
             bm_env->ckks_encoder()->encode(msg, parms_id, scale, pt);
         }
     }
 
     void bm_ckks_decode_double(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<double> &msg = bm_env->msg_double();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<double> msg = bm_env->msg_double();
+        Plaintext pt = bm_env->pt()[0];
+        bm_env->randomize_pt_ckks(pt);
+
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_pt_ckks(pt);
-
-            state.ResumeTiming();
             bm_env->ckks_encoder()->decode(pt, msg);
         }
     }
 
     void bm_ckks_add_ct(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
         double scale = bm_env->safe_scale();
+        bm_env->randomize_ct_ckks(ct[0]);
+        ct[0].scale() = scale;
+        bm_env->randomize_ct_ckks(ct[1]);
+        ct[1].scale() = scale;
+        Ciphertext res;
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-            ct[0].scale() = scale;
-            bm_env->randomize_ct_ckks(ct[1]);
-            ct[1].scale() = scale;
-            state.ResumeTiming();
-            Ciphertext res;
             bm_env->evaluator()->add(ct[0], ct[1], res);
         }
     }
 
     void bm_ckks_add_pt(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
         double scale = bm_env->safe_scale();
+        bm_env->randomize_ct_ckks(ct[0]);
+        ct[0].scale() = scale;
+        bm_env->randomize_pt_ckks(pt);
+        pt.scale() = scale;
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-            ct[0].scale() = scale;
-            bm_env->randomize_pt_ckks(pt);
-            pt.scale() = scale;
-
-            state.ResumeTiming();
             bm_env->evaluator()->add_plain(ct[0], pt, ct[2]);
         }
     }
 
     void bm_ckks_mul_ct(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
         double scale = bm_env->safe_scale();
+        bm_env->randomize_ct_ckks(ct[0]);
+        ct[0].scale() = scale;
+        bm_env->randomize_ct_ckks(ct[1]);
+        ct[1].scale() = scale;
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-            ct[0].scale() = scale;
-            bm_env->randomize_ct_ckks(ct[1]);
-            ct[1].scale() = scale;
-
-            state.ResumeTiming();
             bm_env->evaluator()->multiply(ct[0], ct[1], ct[2]);
         }
     }
 
     void bm_ckks_mul_pt(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
-        Plaintext &pt = bm_env->pt()[0];
+        vector<Ciphertext> ct = bm_env->ct();
+        Plaintext pt = bm_env->pt()[0];
         double scale = bm_env->safe_scale();
+        bm_env->randomize_ct_ckks(ct[0]);
+        ct[0].scale() = scale;
+        bm_env->randomize_pt_ckks(pt);
+        pt.scale() = scale;
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-            ct[0].scale() = scale;
-            bm_env->randomize_pt_ckks(pt);
-            pt.scale() = scale;
-
-            state.ResumeTiming();
             bm_env->evaluator()->multiply_plain(ct[0], pt, ct[2]);
         }
     }
 
     void bm_ckks_square(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
         double scale = bm_env->safe_scale();
+        bm_env->randomize_ct_ckks(ct[0]);
+        ct[0].scale() = scale;
+        bm_env->randomize_ct_ckks(ct[1]);
+        ct[1].scale() = scale;
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-            ct[0].scale() = scale;
-            bm_env->randomize_ct_ckks(ct[1]);
-            ct[1].scale() = scale;
-
-            state.ResumeTiming();
             bm_env->evaluator()->square(ct[0], ct[2]);
         }
     }
 
-    void bm_ckks_rescale_inplace(State &state, shared_ptr<BMEnv> bm_env)
+    void bm_ckks_rescale(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
         double scale = bm_env->safe_scale() * pow(2.0, 20);
+        bm_env->randomize_ct_ckks(ct[0]);
+        ct[0].scale() = scale;
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-            ct[0].scale() = scale;
-
-            state.ResumeTiming();
-            bm_env->evaluator()->rescale_to_next_inplace(ct[0]);
+            bm_env->evaluator()->rescale_to_next(ct[0], ct[1]);
         }
     }
 
-    void bm_ckks_relin_inplace(State &state, shared_ptr<BMEnv> bm_env)
+    void bm_ckks_relin(State &state, shared_ptr<BMEnv> bm_env)
     {
-        Ciphertext ct;
+        vector<Ciphertext> ct = bm_env->ct();
+        ct[0].resize(bm_env->context(), size_t(3));
+        bm_env->randomize_ct_ckks(ct[0]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            ct.resize(bm_env->context(), size_t(3));
-            bm_env->randomize_ct_ckks(ct);
-
-            state.ResumeTiming();
-            bm_env->evaluator()->relinearize_inplace(ct, bm_env->rlk());
+            bm_env->evaluator()->relinearize(ct[0], bm_env->rlk(), ct[1]);
         }
     }
 
     void bm_ckks_rotate(State &state, shared_ptr<BMEnv> bm_env)
     {
-        vector<Ciphertext> &ct = bm_env->ct();
+        vector<Ciphertext> ct = bm_env->ct();
+        bm_env->randomize_ct_ckks(ct[0]);
         for (auto _ : state)
         {
-            state.PauseTiming();
-            bm_env->randomize_ct_ckks(ct[0]);
-
-            state.ResumeTiming();
             bm_env->evaluator()->rotate_vector(ct[0], 1, bm_env->glk(), ct[2]);
         }
     }

--- a/native/src/seal/evaluator.cpp
+++ b/native/src/seal/evaluator.cpp
@@ -617,7 +617,7 @@ namespace seal
         encrypted1.scale() = new_scale;
     }
 
-    void Evaluator::bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool)
+    void Evaluator::bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool) const
     {
         if (encrypted1.is_ntt_form() || encrypted2.is_ntt_form())
         {

--- a/native/src/seal/evaluator.h
+++ b/native/src/seal/evaluator.h
@@ -1017,7 +1017,7 @@ namespace seal
         */
         inline void rotate_columns_inplace(
             Ciphertext &encrypted, const GaloisKeys &galois_keys, MemoryPoolHandle pool = MemoryManager::GetPool()) const
-        {   
+        {
             auto scheme = context_.key_context_data()->parms().scheme();
             if (scheme != scheme_type::bfv && scheme != scheme_type::bgv)
             {
@@ -1204,7 +1204,7 @@ namespace seal
 
         void ckks_multiply(Ciphertext &encrypted1, const Ciphertext &encrypted2, MemoryPoolHandle pool)  const;
 
-        void bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool);
+        void bgv_multiply(Ciphertext &encrypted1, Ciphertext &encrypted2, MemoryPoolHandle pool) const;
 
         void bfv_square(Ciphertext &encrypted, MemoryPoolHandle pool) const;
 


### PR DESCRIPTION
Removes the overhead from due to pausing/resuming in Google benchmarks, which allows removing the iteration count 10. This results in more stable benchmarks and easier control of timings. Note, the EvaluateModSwitch and EvaluateRelin benchmarks are therefore out-of-place. Also avoids using plaintext/ciphertext references, to make benchmarks independent of each other.

Interestingly, this change the performance significantly on some benchmarks. I compiled SEAL with and without HEXL on ICX with clang-10.

E.g., with HEXL=OFF, I'm seeing ~1.4x speedup on CKKS EncodeDouble/DecodeDouble.

With HEXL=ON, I'm seeing significant speedups in CKKS EvaluateMulCt, e.g. on N=8192, (~1.7x), EvaluteMutPt (~2.4x) and EvaluateSquare (~2.1x) speedups compared to before this PR.

I'm not sure why the difference, perhaps reducing the number of cache misses. Anyhow, both [PALISADE](https://gitlab.com/palisade/palisade-development/-/blob/master/benchmark/src/lib-benchmark.cpp), [Lattigo](https://github.com/ldsec/lattigo/blob/master/bfv/bfv_benchmark_test.go), and [HElib](https://github.com/homenc/HElib/blob/master/benchmarks/ckks_basic.cpp) all seem to use the same approach as this PR.

See attached for more details: [seal-bench-remove-random.xlsx](https://github.com/microsoft/SEAL/files/7050467/seal-bench-remove-random.xlsx)
