### PR TITLE
Bump benchmark thirdparty dep to 1.6.0 for upstream change e991355

### DIFF
--- a/cmake/ExternalBenchmark.cmake
+++ b/cmake/ExternalBenchmark.cmake
@@ -4,7 +4,7 @@
 FetchContent_Declare(
     benchmark
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG        c05843a9f622db08ad59804c190f98879b76beba # 1.5.3
+    GIT_TAG        f91b6b42b1b9854772a90ae9501464a161707d1e # 1.6.0
 )
 FetchContent_GetProperties(benchmark)
 


### PR DESCRIPTION
Upstream commit e991355 fixes this warning (that gets promoted to an error via -Werror) in Clang when you try to build for WASM:
```
SEAL/thirdparty/benchmark-src/src/complexity.cc:85:10: error: variable 'sigma_gn' set but not used [-Werror,-Wunused-but-set-variable]
  double sigma_gn = 0.0;
```