### PR TITLE
Bump benchmark thirdparty dep to 1.6.0 for upstream change e991355

### DIFF
--- a/cmake/ExternalBenchmark.cmake
+++ b/cmake/ExternalBenchmark.cmake
@@ -4,7 +4,7 @@
 FetchContent_Declare(
     benchmark
     GIT_REPOSITORY https://github.com/google/benchmark.git
-    GIT_TAG        c05843a9f622db08ad59804c190f98879b76beba # 1.5.3
+    GIT_TAG        f91b6b42b1b9854772a90ae9501464a161707d1e # 1.6.0
 )
 FetchContent_GetProperties(benchmark)
 


### PR DESCRIPTION
This change fixes Clang warning when compiling benchmarks targeting WASM