### PR TITLE
Change logic_assert that throws on bad user input

### DIFF
--- a/native/src/seal/batchencoder.cpp
+++ b/native/src/seal/batchencoder.cpp
@@ -157,7 +157,7 @@ namespace seal
         size_t values_matrix_size = values_matrix.size();
         if (values_matrix_size > slots_)
         {
-            throw logic_error("values_matrix size is too large");
+            throw invalid_argument("values_matrix size is too large");
         }
 #ifdef SEAL_DEBUG
         uint64_t plain_modulus_div_two = modulus >> 1;
@@ -200,7 +200,7 @@ namespace seal
         size_t values_matrix_size = static_cast<size_t>(values_matrix.size());
         if (values_matrix_size > slots_)
         {
-            throw logic_error("values_matrix size is too large");
+            throw invalid_argument("values_matrix size is too large");
         }
 #ifdef SEAL_DEBUG
         uint64_t modulus = context_data.parms().plain_modulus().value();
@@ -241,7 +241,7 @@ namespace seal
         size_t values_matrix_size = static_cast<size_t>(values_matrix.size());
         if (values_matrix_size > slots_)
         {
-            throw logic_error("values_matrix size is too large");
+            throw invalid_argument("values_matrix size is too large");
         }
 #ifdef SEAL_DEBUG
         uint64_t plain_modulus_div_two = modulus >> 1;

--- a/native/src/seal/batchencoder.cpp
+++ b/native/src/seal/batchencoder.cpp
@@ -115,7 +115,7 @@ namespace seal
         size_t values_matrix_size = values_matrix.size();
         if (values_matrix_size > slots_)
         {
-            throw logic_error("values_matrix size is too large");
+            throw invalid_argument("values_matrix size is too large");
         }
 #ifdef SEAL_DEBUG
         uint64_t modulus = context_data.parms().plain_modulus().value();


### PR DESCRIPTION
logic_error should be reserved for internal precondition violation signalling a bug. The particular logic_error in this MR triggers on bad user input rather than an internal error in SEAL.

logic_error isn't (and probably shouldn't be) caught by the C wrapper (BatchEncoder_Encode1), leaking the C++ exception into the host language. This in turn usually causes a crash on bad user input.

This MR changes this a logic_error to invalid_argument.