### PR TITLE
Add SEAL_PURE_SOURCETREE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,19 +101,7 @@ set(SEAL_TARGETS_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/SEALTargets.cmake)
 set(SEAL_CONFIG_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/SEALConfig.cmake)
 set(SEAL_CONFIG_VERSION_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/SEALConfigVersion.cmake)
 set(SEAL_CONFIG_H_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/native/src/seal/util/config.h)
-
-# [option] SEAL_PURE_SOURCETREE (default: OFF)
-set(SEAL_PURE_SOURCETREE_OPTION_STR "When set, the SEAL build will not write any files outside the build directory, including thirdparty dependencies sources.")
-option(SEAL_PURE_SOURCETREE ${SEAL_PURE_SOURCETREE_OPTION_STR} OFF)
-message(STATUS "SEAL_PURE_SOURCETREE: ${SEAL_PURE_SOURCETREE}")
-
-# Build or source tree depending on configuration
-if(${SEAL_PURE_SOURCETREE} )
-    set(SEAL_THIRDPARTY_DIR ${CMAKE_CURRENT_BINARY_DIR}/thirdparty)
-else()
-    set(SEAL_THIRDPARTY_DIR ${CMAKE_CURRENT_LIST_DIR}/thirdparty)
-endif()
-
+set(SEAL_THIRDPARTY_DIR ${CMAKE_CURRENT_BINARY_DIR}/thirdparty)
 
 # Install
 set(SEAL_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/SEAL-${SEAL_VERSION_MAJOR}.${SEAL_VERSION_MINOR})
@@ -731,15 +719,15 @@ endif()
 # Create SEALNet.csproj, SEALNetExamples.csproj, and SEALNetTest.csproj
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/dotnet/src/SEALNet.csproj.in
-    ${CMAKE_CURRENT_LIST_DIR}/dotnet/src/SEALNet.csproj
+    ${CMAKE_CURRENT_BINARY_DIR}/dotnet/src/SEALNet.csproj
     @ONLY)
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/dotnet/tests/SEALNetTest.csproj.in
-    ${CMAKE_CURRENT_LIST_DIR}/dotnet/tests/SEALNetTest.csproj
+    ${CMAKE_CURRENT_BINARY_DIR}/dotnet/tests/SEALNetTest.csproj
     @ONLY)
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/dotnet/examples/SEALNetExamples.csproj.in
-    ${CMAKE_CURRENT_LIST_DIR}/dotnet/examples/SEALNetExamples.csproj
+    ${CMAKE_CURRENT_BINARY_DIR}/dotnet/examples/SEALNetExamples.csproj
     @ONLY)
 
 # Set the sealc dynamic library file names to be included in creating
@@ -750,7 +738,7 @@ configure_file(
 # Create SEALNet-multi.nuspec for a multi-platform NuGet package
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/dotnet/nuget/SEALNet-multi.nuspec.in
-    ${CMAKE_CURRENT_LIST_DIR}/dotnet/nuget/SEALNet-multi.nuspec
+    ${CMAKE_CURRENT_BINARY_DIR}/dotnet/nuget/SEALNet-multi.nuspec
     @ONLY)
 
 set(NUGET_WINDOWS_SEAL_C_PATH "")
@@ -769,5 +757,5 @@ endif()
 # Create SEALNet.nuspec for a local NuGet pack from SEALNet.nuspec.in
 configure_file(
     ${CMAKE_CURRENT_LIST_DIR}/dotnet/nuget/SEALNet.nuspec.in
-    ${CMAKE_CURRENT_LIST_DIR}/dotnet/nuget/SEALNet.nuspec
+    ${CMAKE_CURRENT_BINARY_DIR}/dotnet/nuget/SEALNet.nuspec
     @ONLY)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,6 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Source Tree
 set(SEAL_INCLUDES_DIR ${CMAKE_CURRENT_LIST_DIR}/native/src)
-set(SEAL_THIRDPARTY_DIR ${CMAKE_CURRENT_LIST_DIR}/thirdparty)
 set(SEAL_CONFIG_IN_FILENAME ${CMAKE_CURRENT_LIST_DIR}/cmake/SEALConfig.cmake.in)
 set(SEAL_CONFIG_H_IN_FILENAME ${SEAL_INCLUDES_DIR}/seal/util/config.h.in)
 
@@ -102,6 +101,19 @@ set(SEAL_TARGETS_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/SEALTargets.cmake)
 set(SEAL_CONFIG_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/SEALConfig.cmake)
 set(SEAL_CONFIG_VERSION_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/cmake/SEALConfigVersion.cmake)
 set(SEAL_CONFIG_H_FILENAME ${CMAKE_CURRENT_BINARY_DIR}/native/src/seal/util/config.h)
+
+# [option] SEAL_PURE_SOURCETREE (default: OFF)
+set(SEAL_PURE_SOURCETREE_OPTION_STR "When set, the SEAL build will not write any files outside the build directory, including thirdparty dependencies sources.")
+option(SEAL_PURE_SOURCETREE ${SEAL_PURE_SOURCETREE_OPTION_STR} OFF)
+message(STATUS "SEAL_PURE_SOURCETREE: ${SEAL_PURE_SOURCETREE}")
+
+# Build or source tree depending on configuration
+if(${SEAL_PURE_SOURCETREE} )
+    set(SEAL_THIRDPARTY_DIR ${CMAKE_CURRENT_BINARY_DIR}/thirdparty)
+else()
+    set(SEAL_THIRDPARTY_DIR ${CMAKE_CURRENT_LIST_DIR}/thirdparty)
+endif()
+
 
 # Install
 set(SEAL_CONFIG_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/SEAL-${SEAL_VERSION_MAJOR}.${SEAL_VERSION_MINOR})

--- a/README.md
+++ b/README.md
@@ -411,6 +411,9 @@ The following options can be used with CMake to configure the build. The default
 | SEAL_USE_CXX17         | **ON** / OFF                                                 | Set to `ON` to build Microsoft SEAL as C++17 for a positive performance impact.                                                                                                                        |
 | SEAL_USE_INTRIN        | **ON** / OFF                                                 | Set to `ON` to use compiler intrinsics for improved performance. CMake will automatically detect which intrinsics are available and enable them accordingly.                                           |
 
+| SEAL_PURE_SOURCETREE   | ON / **OFF**
+| When enabled, the SEAL build will only emit files into the cmake build directory. This includes third-party dependencies (both sources and binaries). This flag can improve compatibility with other build systems and enables concurrently building multiple instances of the SEAL library with different `cmake -B` options.
+
 As usual, these options can be passed to CMake with the `-D` flag.
 For example, one could run
 

--- a/README.md
+++ b/README.md
@@ -411,9 +411,6 @@ The following options can be used with CMake to configure the build. The default
 | SEAL_USE_CXX17         | **ON** / OFF                                                 | Set to `ON` to build Microsoft SEAL as C++17 for a positive performance impact.                                                                                                                        |
 | SEAL_USE_INTRIN        | **ON** / OFF                                                 | Set to `ON` to use compiler intrinsics for improved performance. CMake will automatically detect which intrinsics are available and enable them accordingly.                                           |
 
-| SEAL_PURE_SOURCETREE   | ON / **OFF**
-| When enabled, the SEAL build will only emit files into the cmake build directory. This includes third-party dependencies (both sources and binaries). This flag can improve compatibility with other build systems and enables concurrently building multiple instances of the SEAL library with different `cmake -B` options.
-
 As usual, these options can be passed to CMake with the `-D` flag.
 For example, one could run
 

--- a/cmake/ExternalIntelHEXL.cmake
+++ b/cmake/ExternalIntelHEXL.cmake
@@ -27,6 +27,7 @@ if(NOT hexl_POPULATED)
 
     add_subdirectory(
         ${hexl_SOURCE_DIR}
+        ${hexl_SOURCE_DIR}/../hexl-build
         EXCLUDE_FROM_ALL
     )
 endif()

--- a/cmake/ExternalMSGSL.cmake
+++ b/cmake/ExternalMSGSL.cmake
@@ -20,5 +20,6 @@ if(NOT msgsl_POPULATED)
 
     add_subdirectory(
         ${msgsl_SOURCE_DIR}
+        ${msgsl_SOURCE_DIR}/../msgsl-build
         EXCLUDE_FROM_ALL)
 endif()

--- a/cmake/ExternalZLIB.cmake
+++ b/cmake/ExternalZLIB.cmake
@@ -30,5 +30,6 @@ if(NOT zlib_POPULATED)
     set(CMAKE_SUPPRESS_DEVELOPER_WARNINGS TRUE CACHE INTERNAL "Suppress CMP0048 warning" FORCE)
     add_subdirectory(
         ${zlib_SOURCE_DIR}
+        ${zlib_SOURCE_DIR}/../zlib-build
         EXCLUDE_FROM_ALL)
 endif()

--- a/cmake/ExternalZSTD.cmake
+++ b/cmake/ExternalZSTD.cmake
@@ -28,5 +28,6 @@ if(NOT zstd_POPULATED)
 
     add_subdirectory(
         ${zstd_SOURCE_DIR}/build/cmake
+        ${zstd_SOURCE_DIR}/../zstd-build
         EXCLUDE_FROM_ALL)
 endif()

--- a/dotnet/examples/SEALNetExamples.csproj.in
+++ b/dotnet/examples/SEALNetExamples.csproj.in
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(Windows))" Include="@SEAL_WINDOWS_SEAL_C_DIRECTORY@\sealc.dll" />
-    <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(Linux))" Include="@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/libsealc.so.*" />
+    <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(Linux))" Include="@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/libsealc.so*" />
     <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(OSX))" Include="@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/libsealc*.dylib" />
   </ItemGroup>
 
@@ -28,4 +28,7 @@
     <Copy SourceFiles="@(SEALCBinaryFiles)" DestinationFolder="$(TargetDir)" />
   </Target>
 
+  <ItemGroup>
+    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@\dotnet\examples\**\*.cs" />
+  </ItemGroup>
 </Project>

--- a/dotnet/src/SEALNet.csproj.in
+++ b/dotnet/src/SEALNet.csproj.in
@@ -27,4 +27,8 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug'">
     <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@\dotnet\src\**\*.cs" />
+  </ItemGroup>
 </Project>

--- a/dotnet/tests/SEALNetTest.csproj.in
+++ b/dotnet/tests/SEALNetTest.csproj.in
@@ -26,7 +26,7 @@
 
   <ItemGroup>
     <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(Windows))" Include="@SEAL_WINDOWS_SEAL_C_DIRECTORY@\sealc.dll" />
-    <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(Linux))" Include="@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/libsealc.so.*" />
+    <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(Linux))" Include="@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/libsealc.so*" />
     <SEALCBinaryFiles Condition="$([MSBuild]::IsOsPlatform(OSX))" Include="@CMAKE_LIBRARY_OUTPUT_DIRECTORY@/libsealc*.dylib" />
   </ItemGroup>
 
@@ -34,4 +34,7 @@
     <Copy SourceFiles="@(SEALCBinaryFiles)" DestinationFolder="$(TargetDir)" />
   </Target>
 
+  <ItemGroup>
+    <Compile Include="@CMAKE_CURRENT_SOURCE_DIR@\dotnet\tests\**\*.cs" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Add an option so the SEAL build will output all files under the build directory (i.e. the cmake -B directory). This includes thirdparty binaries *and* sources. This improves compatibility with other build systems and allows for concurrent builds of the SEAL library in the same repository, so long as they use separate -B directories.

In particular, I found that concurrent builds would interfere with each other when attempting to clone thirdparty git repos over each other.