### PR TITLE
half guess count in util::try_minimal_primitive_root

### DIFF
--- a/native/src/seal/util/numth.cpp
+++ b/native/src/seal/util/numth.cpp
@@ -406,7 +406,7 @@ namespace seal
             uint64_t current_generator = root;
 
             // destination is going to always contain the smallest generator found
-            for (size_t i = 0; i < degree; i++)
+            for (size_t i = 0; i < degree; i += 2)
             {
                 // If our current generator is strictly smaller than destination,
                 // update


### PR DESCRIPTION
Since we are multiplying `generator_sq` each guess, we should increment `i` by 2 instead of 1.