### PR TITLE
HEXL-SEAL Integration CI

### DIFF
--- a/.github/config-tests/prebuilt_SEAL_w_prebuilt_HEXL.sh
+++ b/.github/config-tests/prebuilt_SEAL_w_prebuilt_HEXL.sh
@@ -1,0 +1,28 @@
+# Build with pre-built HEXL
+set -x
+COMPILER_FLAGS="-DCMAKE_BUILD_TYPE=Release
+                -DSEAL_BUILD_TESTS=OFF
+                -DSEAL_BUILD_BENCH=OFF
+                -DSEAL_BUILD_EXAMPLES=ON
+                -DSEAL_USE_INTEL_HEXL=ON
+                -DSEAL_BUILD_DEPS=OFF
+                -DSEAL_BUILD_SEAL_C=OFF
+                -DSEAL_USE_MSGSL=OFF
+                -DSEAL_USE_ZLIB=OFF
+                -DSEAL_USE_ZSTD=OFF
+                -DBUILD_SHARED_LIBS=OFF
+                -DSEAL_USE_CXX17=OFF
+                -DCMAKE_INSTALL_PREFIX=./"
+
+(
+    cd hexl
+    cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=./
+    cmake --build build -j --config Release
+    cmake --install build --config Release
+)
+
+export HEXL_DIR=$(pwd)/hexl/lib/cmake/hexl-$HEXL_VER
+ls ${HEXL_DIR}
+cmake -B build ${COMPILER_FLAGS} -DCMAKE_MODULE_PATH=${HEXL_DIR} -DHEXL_DIR=${HEXL_DIR}
+cmake --build build -j --config Release
+cmake --build build -j --target install --config Release

--- a/.github/config-tests/prebuilt_SEAL_wo_HEXL.sh
+++ b/.github/config-tests/prebuilt_SEAL_wo_HEXL.sh
@@ -1,0 +1,30 @@
+# Build in debug mode, with prebuilt SEAL, and with no HEXL. Finally, run seal examples.
+set -x
+COMPILER_FLAGS="-DCMAKE_BUILD_TYPE=Debug
+                -DSEAL_BUILD_TESTS=ON
+                -DSEAL_BUILD_BENCH=ON
+                -DSEAL_BUILD_EXAMPLES=OFF
+                -DSEAL_USE_INTEL_HEXL=OFF
+                -DSEAL_BUILD_DEPS=ON
+                -DSEAL_BUILD_SEAL_C=ON
+                -DSEAL_USE_CXX17=ON
+                -DCMAKE_INSTALL_PREFIX=./"
+
+cmake -B build ${COMPILER_FLAGS}
+cmake --build build -j --config Debug
+cmake --build build -j --target install --config Debug
+# File location for sealtest differs for each platform
+sealtest=$(find . -name "sealtest" -o -name "sealtest.exe")
+$sealtest --gtest_output=xml
+
+# Build examples using pre-built SEAL
+export SEAL_DIR=$(pwd)/lib/cmake/SEAL-$SEAL_VER/
+ls ${SEAL_DIR}
+cd native/examples/
+cmake -B build -DSEAL_DIR=${SEAL_DIR} -DCMAKE_MODULE_PATH=${SEAL_DIR}
+cmake --build build -j
+
+# File location for sealexamples differs for each platform
+sealexamples=$(find . -name "sealexamples" -o -name "sealexamples.exe")
+# Run examples 1, 2, 3, 4, 5, and 6 before exiting (0)
+echo 1 2 3 4 5 6 0 | $sealexamples

--- a/.github/config-tests/run_benchmarks_w_HEXL.sh
+++ b/.github/config-tests/run_benchmarks_w_HEXL.sh
@@ -1,0 +1,22 @@
+# Run benchmarks with Release mode and enable HEXL
+set -x
+COMPILER_FLAGS="-DCMAKE_BUILD_TYPE=Release
+                -DSEAL_BUILD_TESTS=ON
+                -DSEAL_BUILD_BENCH=ON
+                -DSEAL_BUILD_EXAMPLES=ON
+                -DSEAL_USE_INTEL_HEXL=ON
+                -DSEAL_BUILD_DEPS=ON
+                -DSEAL_BUILD_SEAL_C=ON
+                -DBUILD_SHARED_LIBS=OFF
+                -DSEAL_USE_CXX17=ON
+                -DCMAKE_INSTALL_PREFIX=./"
+
+cmake -B build ${COMPILER_FLAGS}
+cmake --build build -j --config Release
+cmake --build build -j --target install --config Release
+
+# File location for sealtest and sealbench differs for each platform
+sealtest=$(find . -name "sealtest" -o -name "sealtest.exe")
+sealbench=$(find . -name "sealbench" -o -name "sealbench.exe")
+$sealtest --gtest_output=xml
+$sealbench

--- a/.github/config-tests/run_sealtest_w_HEXL.sh
+++ b/.github/config-tests/run_sealtest_w_HEXL.sh
@@ -1,0 +1,20 @@
+# Build with HEXL
+set -x
+COMPILER_FLAGS="-DCMAKE_BUILD_TYPE=Debug
+                -DSEAL_BUILD_TESTS=ON
+                -DSEAL_BUILD_BENCH=ON
+                -DSEAL_BUILD_EXAMPLES=ON
+                -DSEAL_USE_INTEL_HEXL=ON
+                -DSEAL_BUILD_DEPS=ON
+                -DSEAL_BUILD_SEAL_C=ON
+                -DBUILD_SHARED_LIBS=OFF
+                -DSEAL_USE_CXX17=OFF
+                -DCMAKE_INSTALL_PREFIX=./"
+
+cmake -B build ${COMPILER_FLAGS}
+cmake --build build -j --config Debug
+cmake --build build -j --target install --config Debug
+
+# File location for sealtest differs for each platform
+sealtest=$(find . -name "sealtest" -o -name "sealtest.exe")
+$sealtest --gtest_output=xml

--- a/.github/config-tests/shared_lib_w_HEXL.sh
+++ b/.github/config-tests/shared_lib_w_HEXL.sh
@@ -1,0 +1,20 @@
+# Build shared lib
+set -x
+COMPILER_FLAGS="-DCMAKE_BUILD_TYPE=Release
+                -DSEAL_BUILD_TESTS=ON
+                -DSEAL_BUILD_BENCH=ON
+                -DSEAL_BUILD_EXAMPLES=ON
+                -DSEAL_USE_INTEL_HEXL=ON
+                -DSEAL_BUILD_DEPS=ON
+                -DSEAL_BUILD_SEAL_C=OFF
+                -DBUILD_SHARED_LIBS=ON
+                -DSEAL_USE_CXX17=OFF
+                -DCMAKE_INSTALL_PREFIX=./"
+
+cmake -B build ${COMPILER_FLAGS}
+cmake --build build -j
+cmake --build build -j --target install
+
+# File location for sealtest differs for each platform
+sealtest=$(find . -name "sealtest")
+$sealtest --gtest_output=xml

--- a/.github/config-tests/shared_lib_w_prebuilt_HEXL.sh
+++ b/.github/config-tests/shared_lib_w_prebuilt_HEXL.sh
@@ -1,0 +1,28 @@
+# Build with pre-built HEXL and shared lib
+set -x
+COMPILER_FLAGS="-DCMAKE_BUILD_TYPE=Debug
+                -DSEAL_BUILD_TESTS=OFF
+                -DSEAL_BUILD_BENCH=OFF
+                -DSEAL_BUILD_EXAMPLES=ON
+                -DSEAL_USE_INTEL_HEXL=ON
+                -DSEAL_BUILD_DEPS=OFF
+                -DSEALg_BUILD_SEAL_C=OFF
+                -DSEAL_USE_MSGSL=OFF
+                -DSEAL_USE_ZLIB=OFF
+                -DSEAL_USE_ZSTD=OFF
+                -DBUILD_SHARED_LIBS=ON
+                -DSEAL_USE_CXX17=ON
+                -DCMAKE_INSTALL_PREFIX=./"
+
+(
+    cd hexl
+    cmake -B build -DCMAKE_INSTALL_PREFIX=./
+    cmake --build build -j
+    cmake --install build
+)
+
+export HEXL_DIR=$(pwd)/hexl/lib/cmake/hexl-$HEXL_VER
+ls ${HEXL_DIR}
+cmake -B build ${COMPILER_FLAGS} -DCMAKE_MODULE_PATH=${HEXL_DIR} -DHEXL_DIR=${HEXL_DIR}
+cmake --build build -j
+cmake --build build -j --target install

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -1,0 +1,80 @@
+name: Build and Test
+on:
+  # Schedule run every week at 8AM UTC (midnight PST)
+  schedule:
+    - cron: '0 8 * * SUN'
+  
+  # By default this will run when the activity type is "opened", "synchronize",
+  # or "reopened".
+  pull_request:
+    branches:
+      - main
+      - contrib
+      - "[0-9]+.[0-9]+.[0-9]+" # Run on release branch, e.g. 1.2.0
+  
+  # Run when protected branches are pushed to, e.g. via merge
+  push:
+    branches:
+      - main
+      - contrib
+      - "[0-9]+.[0-9]+.[0-9]+" # Run on release branch, e.g. 1.2.0
+
+  # Manually run this workflow on any specified branch.
+  workflow_dispatch:
+
+
+###################
+# Define env vars #
+###################
+env:
+  HEXL_VER: 1.2.3
+  SEAL_VER: 3.7
+
+jobs:
+  # Grab tests from config-tests dir and format into JSON object to reuse in workflow
+  find-scripts:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: set-matrix
+        run: |
+          matrix=$(python3 -c 'import os, json; print(json.dumps(os.listdir(".github/config-tests")))')
+          echo $matrix
+          echo "::set-output name=matrix::$matrix"
+  
+  # Execute scripts found in previous job
+  config:
+    needs: find-scripts
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        script: ${{ fromJson(needs.find-scripts.outputs.matrix) }}
+        exclude:
+          # Windows only supports static builds, don't build w/ shared
+          - os: windows-2019
+            script: shared_lib_w_HEXL.sh
+          - os: windows-2019
+            script: shared_lib_w_prebuilt_HEXL.sh
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Checkout hexl
+        uses: actions/checkout@v2
+        with:
+          repository: intel/hexl
+          ref: v${{ env.HEXL_VER }}
+          fetch-depth: 1
+          path: hexl
+
+      - name: Run Config
+        run: |
+          set -xeuo pipefail
+          ./.github/config-tests/${{ matrix.script }}


### PR DESCRIPTION
CI that tests the integration of building HEXL with SEAL using different compiler configurations.
- Runs on MacOS 10.15, Ubuntu 20.04, and Windows 2019 at 12AM PST every Sunday.

**Note:** To start running the CI, there needs to be a file with the same name in this PR (`github-ci.yml`) in the `main` branch for GitHub Actions to recognise a new workflow. This file cannot be empty and requires some minimal content.

Co-authored-by: @ajagann