### PR TITLE
Wasm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -511,14 +511,6 @@ mark_as_advanced(SEAL_BUILD_STATIC_SEAL_C)
 
 # Create SEAL_C library but add no source files yet
 if(SEAL_BUILD_SEAL_C)
-    # Check that size_t is 8 bytes
-    include(CheckTypeSize)
-    check_type_size("size_t" SIZET LANGUAGE C)
-    if(NOT ${SIZET} EQUAL 8)
-        unset(SIZET CACHE)
-        unset(HAVE_SIZET CACHE)
-        message(FATAL_ERROR "SEAL_C requires 64-bit platform")
-    endif()
     unset(SIZET CACHE)
     unset(HAVE_SIZET CACHE)
 

--- a/native/src/seal/c/defines.h
+++ b/native/src/seal/c/defines.h
@@ -3,14 +3,8 @@
 
 #pragma once
 
-// STD
-#include <cstddef>
-
 // SEALNet
 #include "seal/c/stdafx.h"
-
-// Check that std::size_t is 64 bits
-static_assert(sizeof(std::size_t) == 8, "Require sizeof(std::size_t) == 8");
 
 #ifdef _MSC_VER
 


### PR DESCRIPTION
Remove "size_t is 64-bit" checks so we can build SEAL C library with WASM32.