### PR TITLE
fix comments typos in decryptor.h

### DIFF
--- a/native/src/seal/decryptor.h
+++ b/native/src/seal/decryptor.h
@@ -92,7 +92,7 @@ namespace seal
         becomes too noisy to decrypt correctly.
 
         @param[in] encrypted The ciphertext
-        @throws std::invalid_argument if the scheme is not BFV
+        @throws std::invalid_argument if the scheme is not BFV/BGV
         @throws std::invalid_argument if encrypted is not valid for the encryption
         parameters
         @throws std::invalid_argument if encrypted is in NTT form


### PR DESCRIPTION
in the current comment is mentioned that an exception of type std::invalid_argument will be thrown if scheme is not BFV which is not the case in encryptor.cpp (BGV is supported as well), also I think that the exception should be logic_error instead of invalid_argument in the same comment line.