### PR TITLE
Update README info to correct library versions being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,12 +131,12 @@ The optional dependencies and their tested versions (other versions may work as 
 
 | Optional dependency                                    | Tested version | Use                                              |
 | ------------------------------------------------------ | -------------- | ------------------------------------------------ |
-| [Intel HEXL](https://github.com/intel/hexl)            | 1.2.3          | Acceleration of low-level kernels                |
-| [Microsoft GSL](https://github.com/microsoft/GSL)      | 3.1.0          | API extensions                                   |
-| [ZLIB](https://github.com/madler/zlib)                 | 1.2.11         | Compressed serialization                         |
-| [Zstandard](https://github.com/facebook/zstd)          | 1.4.5          | Compressed serialization (much faster than ZLIB) |
-| [GoogleTest](https://github.com/google/googletest)     | 1.11.0         | For running tests                                |
-| [GoogleBenchmark](https://github.com/google/benchmark) | 1.6.0          | For running benchmarks                           |
+| [Intel HEXL](https://github.com/intel/hexl)            | 1.2.5          | Acceleration of low-level kernels                |
+| [Microsoft GSL](https://github.com/microsoft/GSL)      | 4.0.0          | API extensions                                   |
+| [ZLIB](https://github.com/madler/zlib)                 | 1.2.13         | Compressed serialization                         |
+| [Zstandard](https://github.com/facebook/zstd)          | 1.5.2          | Compressed serialization (much faster than ZLIB) |
+| [GoogleTest](https://github.com/google/googletest)     | 1.12.1         | For running tests                                |
+| [GoogleBenchmark](https://github.com/google/benchmark) | 1.7.1          | For running benchmarks                           |
 
 #### Intel HEXL
 


### PR DESCRIPTION
The library versions being used according to the readme are correct for seal 4.0.0 not seal 4.1.0, I updated to the current versions