### PR TITLE
cmake: update cmake config per 4.1.1 release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT CMAKE_BUILD_TYPE)
 endif()
 message(STATUS "Build type (CMAKE_BUILD_TYPE): ${CMAKE_BUILD_TYPE}")
 
-project(SEAL VERSION 4.1.0 LANGUAGES CXX C)
+project(SEAL VERSION 4.1.1 LANGUAGES CXX C)
 
 ########################
 # Global configuration #

--- a/native/bench/CMakeLists.txt
+++ b/native/bench/CMakeLists.txt
@@ -3,14 +3,14 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project(SEALBench VERSION 4.1.0 LANGUAGES CXX)
+project(SEALBench VERSION 4.1.1 LANGUAGES CXX)
 
 # If not called from root CMakeLists.txt
 if(NOT DEFINED SEAL_BUILD_BENCH)
     set(SEAL_BUILD_BENCH ON)
 
     # Import Microsoft SEAL
-    find_package(SEAL 4.1.0 EXACT REQUIRED)
+    find_package(SEAL 4.1.1 EXACT REQUIRED)
 
     # Must define these variables and include macros
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${OUTLIB_PATH})

--- a/native/examples/CMakeLists.txt
+++ b/native/examples/CMakeLists.txt
@@ -3,14 +3,14 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project(SEALExamples VERSION 4.1.0 LANGUAGES CXX)
+project(SEALExamples VERSION 4.1.1 LANGUAGES CXX)
 
 # If not called from root CMakeLists.txt
 if(NOT DEFINED SEAL_BUILD_EXAMPLES)
     set(SEAL_BUILD_EXAMPLES ON)
 
     # Import Microsoft SEAL
-    find_package(SEAL 4.1.0 EXACT REQUIRED)
+    find_package(SEAL 4.1.1 EXACT REQUIRED)
 
     set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/bin)
 endif()

--- a/native/tests/CMakeLists.txt
+++ b/native/tests/CMakeLists.txt
@@ -3,14 +3,14 @@
 
 cmake_minimum_required(VERSION 3.13)
 
-project(SEALTest VERSION 4.1.0 LANGUAGES CXX C)
+project(SEALTest VERSION 4.1.1 LANGUAGES CXX C)
 
 # If not called from root CMakeLists.txt
 if(NOT DEFINED SEAL_BUILD_TESTS)
     set(SEAL_BUILD_TESTS ON)
 
     # Import Microsoft SEAL
-    find_package(SEAL 4.1.0 EXACT REQUIRED)
+    find_package(SEAL 4.1.1 EXACT REQUIRED)
 
     # Must define these variables and include macros
     set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${OUTLIB_PATH})


### PR DESCRIPTION
Looks like the version config on the cmake files got missed out per the release process. Updating all the cmake configs.

relates to https://github.com/Homebrew/homebrew-core/pull/119758