### PR TITLE
Removed unqualified calls to std::move

### DIFF
--- a/native/src/seal/context.cpp
+++ b/native/src/seal/context.cpp
@@ -438,7 +438,7 @@ namespace seal
         }
 
         // Add them to the context_data_map_
-        context_data_map_.emplace(make_pair(next_parms_id, make_shared<const ContextData>(move(next_context_data))));
+        context_data_map_.emplace(make_pair(next_parms_id, make_shared<const ContextData>(std::move(next_context_data))));
 
         // Add pointer to next context_data to the previous one (linked list)
         // Add pointer to previous context_data to the next one (doubly linked list)
@@ -453,7 +453,7 @@ namespace seal
 
     SEALContext::SEALContext(
         EncryptionParameters parms, bool expand_mod_chain, sec_level_type sec_level, MemoryPoolHandle pool)
-        : pool_(move(pool)), sec_level_(sec_level)
+        : pool_(std::move(pool)), sec_level_(sec_level)
     {
         if (!pool_)
         {

--- a/native/src/seal/decryptor.cpp
+++ b/native/src/seal/decryptor.cpp
@@ -291,7 +291,7 @@ namespace seal
 
         // Acquire new array
         secret_key_array_size_ = new_size;
-        secret_key_array_.acquire(move(secret_key_array));
+        secret_key_array_.acquire(std::move(secret_key_array));
     }
 
     // Compute c_0 + c_1 *s + ... + c_{count-1} * s^{count-1} mod q.

--- a/native/src/seal/evaluator.cpp
+++ b/native/src/seal/evaluator.cpp
@@ -852,15 +852,15 @@ namespace seal
         switch (context_data_ptr->parms().scheme())
         {
         case scheme_type::bfv:
-            bfv_square(encrypted, move(pool));
+            bfv_square(encrypted, std::move(pool));
             break;
 
         case scheme_type::ckks:
-            ckks_square(encrypted, move(pool));
+            ckks_square(encrypted, std::move(pool));
             break;
 
         case scheme_type::bgv:
-            bgv_square(encrypted, move(pool));
+            bgv_square(encrypted, std::move(pool));
             break;
 
         default:
@@ -897,7 +897,7 @@ namespace seal
         // Optimization implemented currently only for size 2 ciphertexts
         if (encrypted_size != 2)
         {
-            bfv_multiply(encrypted, encrypted, move(pool));
+            bfv_multiply(encrypted, encrypted, std::move(pool));
             return;
         }
 
@@ -1036,7 +1036,7 @@ namespace seal
         // Optimization implemented currently only for size 2 ciphertexts
         if (encrypted_size != 2)
         {
-            ckks_multiply(encrypted, encrypted, move(pool));
+            ckks_multiply(encrypted, encrypted, std::move(pool));
             return;
         }
 
@@ -1097,7 +1097,7 @@ namespace seal
         // Optimization implemented currently only for size 2 ciphertexts
         if (encrypted_size != 2)
         {
-            bgv_multiply(encrypted, encrypted, move(pool));
+            bgv_multiply(encrypted, encrypted, std::move(pool));
             return;
         }
 
@@ -1402,16 +1402,16 @@ namespace seal
         {
         case scheme_type::bfv:
             // Modulus switching with scaling
-            mod_switch_scale_to_next(encrypted, destination, move(pool));
+            mod_switch_scale_to_next(encrypted, destination, std::move(pool));
             break;
 
         case scheme_type::ckks:
             // Modulus switching without scaling
-            mod_switch_drop_to_next(encrypted, destination, move(pool));
+            mod_switch_drop_to_next(encrypted, destination, std::move(pool));
             break;
 
         case scheme_type::bgv:
-            mod_switch_scale_to_next(encrypted, destination, move(pool));
+            mod_switch_scale_to_next(encrypted, destination, std::move(pool));
             break;
 
         default:
@@ -1503,7 +1503,7 @@ namespace seal
 
         case scheme_type::ckks:
             // Modulus switching with scaling
-            mod_switch_scale_to_next(encrypted, destination, move(pool));
+            mod_switch_scale_to_next(encrypted, destination, std::move(pool));
             break;
 
         default:
@@ -1682,7 +1682,7 @@ namespace seal
                 multiply(encrypteds[i], encrypteds[i + 1], temp);
             }
             relinearize_inplace(temp, relin_keys, pool);
-            product_vec.emplace_back(move(temp));
+            product_vec.emplace_back(std::move(temp));
         }
         if (encrypteds.size() & 1)
         {
@@ -1695,7 +1695,7 @@ namespace seal
             Ciphertext temp(context_, context_data.parms_id(), pool);
             multiply(product_vec[i], product_vec[i + 1], temp);
             relinearize_inplace(temp, relin_keys, pool);
-            product_vec.emplace_back(move(temp));
+            product_vec.emplace_back(std::move(temp));
         }
 
         destination = product_vec.back();
@@ -1731,7 +1731,7 @@ namespace seal
 
         // Create a vector of copies of encrypted
         vector<Ciphertext> exp_vector(static_cast<size_t>(exponent), encrypted);
-        multiply_many(exp_vector, relin_keys, encrypted, move(pool));
+        multiply_many(exp_vector, relin_keys, encrypted, std::move(pool));
     }
 
     void Evaluator::add_plain_inplace(Ciphertext &encrypted, const Plaintext &plain, MemoryPoolHandle pool) const
@@ -1823,7 +1823,7 @@ namespace seal
             multiply_poly_scalar_coeffmod(
                 plain.data(), plain.coeff_count(), encrypted.correction_factor(), parms.plain_modulus(),
                 plain_copy.data());
-            transform_to_ntt_inplace(plain_copy, encrypted.parms_id(), move(pool));
+            transform_to_ntt_inplace(plain_copy, encrypted.parms_id(), std::move(pool));
             RNSIter encrypted_iter(encrypted.data(), coeff_count);
             ConstRNSIter plain_iter(plain_copy.data(), coeff_count);
             add_poly_coeffmod(encrypted_iter, plain_iter, coeff_modulus_size, coeff_modulus, encrypted_iter);
@@ -1931,7 +1931,7 @@ namespace seal
             multiply_poly_scalar_coeffmod(
                 plain.data(), plain.coeff_count(), encrypted.correction_factor(), parms.plain_modulus(),
                 plain_copy.data());
-            transform_to_ntt_inplace(plain_copy, encrypted.parms_id(), move(pool));
+            transform_to_ntt_inplace(plain_copy, encrypted.parms_id(), std::move(pool));
             RNSIter encrypted_iter(encrypted.data(), coeff_count);
             ConstRNSIter plain_iter(plain_copy.data(), coeff_count);
             sub_poly_coeffmod(encrypted_iter, plain_iter, coeff_modulus_size, coeff_modulus, encrypted_iter);
@@ -1972,12 +1972,12 @@ namespace seal
         }
         else if (!encrypted.is_ntt_form() && !plain.is_ntt_form())
         {
-            multiply_plain_normal(encrypted, plain, move(pool));
+            multiply_plain_normal(encrypted, plain, std::move(pool));
         }
         else if (encrypted.is_ntt_form() && !plain.is_ntt_form())
         {
             Plaintext plain_copy = plain;
-            transform_to_ntt_inplace(plain_copy, encrypted.parms_id(), move(pool));
+            transform_to_ntt_inplace(plain_copy, encrypted.parms_id(), std::move(pool));
             multiply_plain_ntt(encrypted, plain_copy);
         }
         else
@@ -2493,7 +2493,7 @@ namespace seal
         if (galois_keys.has_key(galois_tool->get_elt_from_step(steps)))
         {
             // Perform rotation and key switching
-            apply_galois_inplace(encrypted, galois_tool->get_elt_from_step(steps), galois_keys, move(pool));
+            apply_galois_inplace(encrypted, galois_tool->get_elt_from_step(steps), galois_keys, std::move(pool));
         }
         else
         {

--- a/native/src/seal/kswitchkeys.cpp
+++ b/native/src/seal/kswitchkeys.cpp
@@ -124,7 +124,7 @@ namespace seal
                 {
                     PublicKey key(pool_);
                     key.unsafe_load(context, stream);
-                    new_keys[index].emplace_back(move(key));
+                    new_keys[index].emplace_back(std::move(key));
                 }
             }
         }

--- a/native/src/seal/util/croots.cpp
+++ b/native/src/seal/util/croots.cpp
@@ -15,7 +15,7 @@ namespace seal
         constexpr double ComplexRoots::PI_;
 
         ComplexRoots::ComplexRoots(size_t degree_of_roots, MemoryPoolHandle pool)
-            : degree_of_roots_(degree_of_roots), pool_(move(pool))
+            : degree_of_roots_(degree_of_roots), pool_(std::move(pool))
         {
 #ifdef SEAL_DEBUG
             int power = util::get_power_of_two(degree_of_roots_);

--- a/native/src/seal/util/galois.cpp
+++ b/native/src/seal/util/galois.cpp
@@ -47,7 +47,7 @@ namespace seal
             {
                 return;
             }
-            result.acquire(move(temp));
+            result.acquire(std::move(temp));
         }
 
         uint32_t GaloisTool::get_elt_from_step(int step) const

--- a/native/src/seal/util/ntt.cpp
+++ b/native/src/seal/util/ntt.cpp
@@ -179,7 +179,7 @@ namespace intel
             if (ntt_it == ntt_cache_.end())
             {
                 hexl::NTT ntt(N, modulus, root, seal::MemoryManager::GetPool(), hexl::SimpleThreadSafePolicy{});
-                ntt_it = ntt_cache_.emplace(move(key), move(ntt)).first;
+                ntt_it = ntt_cache_.emplace(std::move(key), std::move(ntt)).first;
             }
             return ntt_it->second;
         }
@@ -226,7 +226,7 @@ namespace seal
 {
     namespace util
     {
-        NTTTables::NTTTables(int coeff_count_power, const Modulus &modulus, MemoryPoolHandle pool) : pool_(move(pool))
+        NTTTables::NTTTables(int coeff_count_power, const Modulus &modulus, MemoryPoolHandle pool) : pool_(std::move(pool))
         {
 #ifdef SEAL_DEBUG
             if (!pool_)
@@ -316,7 +316,7 @@ namespace seal
 
             // Other constructors
             NTTTablesCreateIter(int coeff_count_power, vector<Modulus> modulus, MemoryPoolHandle pool)
-                : coeff_count_power_(coeff_count_power), modulus_(modulus), pool_(move(pool))
+                : coeff_count_power_(coeff_count_power), modulus_(modulus), pool_(std::move(pool))
             {}
 
             // Require copy and move constructors and assignments

--- a/native/src/seal/util/numth.cpp
+++ b/native/src/seal/util/numth.cpp
@@ -298,7 +298,7 @@ namespace seal
                 Modulus new_mod(value);
                 if (new_mod.is_prime())
                 {
-                    destination.emplace_back(move(new_mod));
+                    destination.emplace_back(std::move(new_mod));
                     count--;
                 }
                 value -= factor;

--- a/native/src/seal/util/rns.cpp
+++ b/native/src/seal/util/rns.cpp
@@ -16,7 +16,7 @@ namespace seal
     namespace util
     {
         RNSBase::RNSBase(const vector<Modulus> &rnsbase, MemoryPoolHandle pool)
-            : pool_(move(pool)), size_(rnsbase.size())
+            : pool_(std::move(pool)), size_(rnsbase.size())
         {
             if (!size_)
             {
@@ -56,7 +56,7 @@ namespace seal
             }
         }
 
-        RNSBase::RNSBase(const RNSBase &copy, MemoryPoolHandle pool) : pool_(move(pool)), size_(copy.size_)
+        RNSBase::RNSBase(const RNSBase &copy, MemoryPoolHandle pool) : pool_(std::move(pool)), size_(copy.size_)
         {
             if (!pool_)
             {
@@ -564,7 +564,7 @@ namespace seal
         RNSTool::RNSTool(
             size_t poly_modulus_degree, const RNSBase &coeff_modulus, const Modulus &plain_modulus,
             MemoryPoolHandle pool)
-            : pool_(move(pool))
+            : pool_(std::move(pool))
         {
 #ifdef SEAL_DEBUG
             if (!pool_)

--- a/native/src/seal/util/ztools.cpp
+++ b/native/src/seal/util/ztools.cpp
@@ -34,14 +34,14 @@ namespace seal
                 class PointerStorage
                 {
                 public:
-                    PointerStorage(MemoryPoolHandle pool) : pool_(move(pool))
+                    PointerStorage(MemoryPoolHandle pool) : pool_(std::move(pool))
                     {}
 
                     void *allocate(size_t size)
                     {
                         auto ptr = util::allocate<seal_byte>(size, pool_);
                         void *addr = reinterpret_cast<void *>(ptr.get());
-                        ptr_storage_[addr] = move(ptr);
+                        ptr_storage_[addr] = std::move(ptr);
                         return addr;
                     }
 
@@ -392,7 +392,7 @@ namespace seal
             {
                 Serialization::SEALHeader &header = *reinterpret_cast<Serialization::SEALHeader *>(header_ptr);
 
-                auto ret = zlib_deflate_array_inplace(in, move(pool));
+                auto ret = zlib_deflate_array_inplace(in, std::move(pool));
                 if (Z_OK != ret)
                 {
                     stringstream ss;
@@ -752,7 +752,7 @@ namespace seal
             {
                 Serialization::SEALHeader &header = *reinterpret_cast<Serialization::SEALHeader *>(header_ptr);
 
-                auto ret = zstd_deflate_array_inplace(in, move(pool));
+                auto ret = zstd_deflate_array_inplace(in, std::move(pool));
                 if (ZSTD_error_no_error != ret)
                 {
                     stringstream ss;


### PR DESCRIPTION
Aims to fix the flood of warnings given by Clang because of unqualified calls to `std::move`.