### PR TITLE
shifting by a larger amount should be allowable

### DIFF
--- a/native/src/seal/util/polyarithsmallmod.cpp
+++ b/native/src/seal/util/polyarithsmallmod.cpp
@@ -340,7 +340,7 @@ namespace seal
             {
                 throw invalid_argument("coeff_count");
             }
-            if (shift >= coeff_count)
+            if (shift >= 2 * coeff_count)
             {
                 throw invalid_argument("shift");
             }


### PR DESCRIPTION
The ring of cyclotomic integers has the relation (`x^n + 1 = 0`) introduced by modding out `Z[x]` by the ideal `(x^n+1)`. In the code, `coeff_count` is `n`. Shifting a polynomial `p(x)` (in the ring of cyclotomic integers) by `n` (or multiplying by `x^n`) negates all the coefficients in the polynomial: `-p(x)`. Shifting by another `n` results in the original polynomial `p(x)`. I believe that the intent of the original `if` statement `throw`ing is that if the programmer is shifting by a large amount, then maybe the programmer does not have a good grasp on what is occurring. It isn't wrong, but the programmer should be notified (in debug mode).

Moreover, if one looks at [PIRServer::expand_query](https://github.com/microsoft/SealPIR/blob/master/src/pir_server.cpp) and follow the function calls to `negacyclic_shift_poly_coeffmod` with the value of shift being `index`. In the calling function, `index` is defined as:
```
auto n = enc_params_.poly_modulus_degree();
...
int index = (index_raw * galois_elts[i]) % (n << 1);
```
The important thing to note is that `index` is created by modding out by `n << 1` (or equivalently `2 * n`).