### PR TITLE
docs: Update unlinked references in the document

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The [APSI library for Asymmetric PSI](https://eprint.iacr.org/2021/1116) is avai
     - [Basic CMake Options](#basic-cmake-options)
     - [Advanced CMake Options](#advanced-cmake-options)
     - [Linking with Microsoft SEAL through CMake](#linking-with-microsoft-seal-through-cmake)
-    - [Examples, Tests, and Benchmark](#examples-tests-and-benchmark)
+    - [Examples, Tests, and Benchmark](#examples-tests-and-benchmarks)
   - [Building .NET Components](#building-net-components)
     - [Windows, Linux, and macOS](#windows-linux-and-macos)
     - [Android and iOS](#android-and-ios)
@@ -215,7 +215,7 @@ The examples are available (and identical) in C++ and C#, and are divided into s
 
 It is recommended to read the comments and the code snippets along with command line printout from running an example.
 For easier navigation, command line printout provides the line number in the associated source file where the associated code snippets start.
-To build the examples, see [Examples, Tests, and Benchmark](#examples-tests-and-benchmark) (C++) and [Building .NET Components](#building-net-components) (C#).
+To build the examples, see [Examples, Tests, and Benchmark](#examples-tests-and-benchmarks) (C++) and [Building .NET Components](#building-net-components) (C#).
 
 **Note:** It is impossible to know how to use Microsoft SEAL correctly without studying examples 1&ndash;6.
 They are designed to provide the reader with the necessary conceptual background on homomorphic encryption.


### PR DESCRIPTION
While looking at the official documentation for Microsoft's SEAL, I noticed some links that didn't connect because of a typo