### PR TITLE
Remove extra semicolons

### DIFF
--- a/native/src/seal/util/iterator.h
+++ b/native/src/seal/util/iterator.h
@@ -1837,7 +1837,7 @@ namespace seal
 
             IterTuple() = default;
 
-            IterTuple(SEALIter first, IterTuple<Rest...> rest) : first_(first), rest_(rest){};
+            IterTuple(SEALIter first, IterTuple<Rest...> rest) : first_(first), rest_(rest){}
 
             IterTuple(SEALIter first, Rest... rest) : first_(first), rest_(rest...)
             {}
@@ -2061,7 +2061,7 @@ namespace seal
             using iterator_category = std::random_access_iterator_tag;
             using difference_type = std::ptrdiff_t;
 
-            IterTuple(){};
+            IterTuple(){}
 
             IterTuple(SEALIter first) : first_(first)
             {}

--- a/native/src/seal/util/mempool.h
+++ b/native/src/seal/util/mempool.h
@@ -228,7 +228,7 @@ namespace seal
         class MemoryPoolMT : public MemoryPool
         {
         public:
-            MemoryPoolMT(bool clear_on_destruction = false) : clear_on_destruction_(clear_on_destruction){};
+            MemoryPoolMT(bool clear_on_destruction = false) : clear_on_destruction_(clear_on_destruction){}
 
             ~MemoryPoolMT() noexcept override;
 
@@ -257,7 +257,7 @@ namespace seal
         class MemoryPoolST : public MemoryPool
         {
         public:
-            MemoryPoolST(bool clear_on_destruction = false) : clear_on_destruction_(clear_on_destruction){};
+            MemoryPoolST(bool clear_on_destruction = false) : clear_on_destruction_(clear_on_destruction){}
 
             ~MemoryPoolST() noexcept override;
 


### PR DESCRIPTION
When compiling with -Wextra-semi warnings get called out in this codebase for extra semicolons.  This commit removes the extra semicolons.