### PR TITLE
add check for capacity size before allocating memory

### DIFF
--- a/native/src/seal/dynarray.h
+++ b/native/src/seal/dynarray.h
@@ -424,6 +424,11 @@ namespace seal
         */
         inline void reserve(std::size_t capacity)
         {
+
+            // Check if capacity is greater than capacity_ before allocating memory
+            if (capacity <= capacity_) {
+                return;
+            }
             std::size_t copy_size = std::min<>(capacity, size_);
 
             // Create new allocation and copy over value


### PR DESCRIPTION
https://github.com/microsoft/SEAL/issues/693#issue-2337681575

Added a check in [/native/src/seal/dynarray.h] to see if capacity > capacity_ before memory allocation