### PR TITLE
Upgrade `zlib` and `zstd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ The optional dependencies and their tested versions (other versions may work as 
 | ------------------------------------------------------ | -------------- | ------------------------------------------------ |
 | [Intel HEXL](https://github.com/intel/hexl)            | 1.2.5          | Acceleration of low-level kernels                |
 | [Microsoft GSL](https://github.com/microsoft/GSL)      | 4.0.0          | API extensions                                   |
-| [ZLIB](https://github.com/madler/zlib)                 | 1.2.13         | Compressed serialization                         |
+| [ZLIB](https://github.com/madler/zlib)                 | 1.3.1          | Compressed serialization                         |
 | [Zstandard](https://github.com/facebook/zstd)          | 1.5.2          | Compressed serialization (much faster than ZLIB) |
 | [GoogleTest](https://github.com/google/googletest)     | 1.12.1         | For running tests                                |
 | [GoogleBenchmark](https://github.com/google/benchmark) | 1.7.1          | For running benchmarks                           |

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The optional dependencies and their tested versions (other versions may work as 
 | [Intel HEXL](https://github.com/intel/hexl)            | 1.2.5          | Acceleration of low-level kernels                |
 | [Microsoft GSL](https://github.com/microsoft/GSL)      | 4.0.0          | API extensions                                   |
 | [ZLIB](https://github.com/madler/zlib)                 | 1.3.1          | Compressed serialization                         |
-| [Zstandard](https://github.com/facebook/zstd)          | 1.5.2          | Compressed serialization (much faster than ZLIB) |
+| [Zstandard](https://github.com/facebook/zstd)          | 1.5.7          | Compressed serialization (much faster than ZLIB) |
 | [GoogleTest](https://github.com/google/googletest)     | 1.12.1         | For running tests                                |
 | [GoogleBenchmark](https://github.com/google/benchmark) | 1.7.1          | For running benchmarks                           |
 

--- a/cmake/ExternalZLIB.cmake
+++ b/cmake/ExternalZLIB.cmake
@@ -3,7 +3,7 @@
 FetchContent_Declare(
     zlib
     GIT_REPOSITORY https://github.com/madler/zlib.git
-    GIT_TAG        04f42ceca40f73e2978b50e93806c2a18c1281fc # 1.2.13
+    GIT_TAG        1a8db63788c34a50e39e273d39b7e1033208aea2 # 1.3.1
 )
 FetchContent_GetProperties(zlib)
 if(NOT zlib_POPULATED)

--- a/cmake/ExternalZLIB.cmake
+++ b/cmake/ExternalZLIB.cmake
@@ -3,7 +3,7 @@
 FetchContent_Declare(
     zlib
     GIT_REPOSITORY https://github.com/madler/zlib.git
-    GIT_TAG        1a8db63788c34a50e39e273d39b7e1033208aea2 # 1.3.1
+    GIT_TAG        51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf # 1.3.1
 )
 FetchContent_GetProperties(zlib)
 if(NOT zlib_POPULATED)

--- a/cmake/ExternalZSTD.cmake
+++ b/cmake/ExternalZSTD.cmake
@@ -4,7 +4,7 @@
 FetchContent_Declare(
     zstd
     GIT_REPOSITORY https://github.com/facebook/zstd.git
-    GIT_TAG        e47e674cd09583ff0503f0f6defd6d23d8b718d3 # 1.5.2
+    GIT_TAG        f8745da6ff1ad1e7bab384bd1f9d742439278e99 # 1.5.7
 )
 FetchContent_GetProperties(zstd)
 if(NOT zstd_POPULATED)


### PR DESCRIPTION
# Upgrade `zlib` and `zstd`

This PR bumps optional dependency `zlib` from version 1.2.13 to 1.3.1 and `zstd` from version 1.5.2 to 1.5.7.

## Motivations

Updating these two optional (but default) dependencies to their last versions also bump CMake requirements to 3.13 (same as SEAL). This allow building the project with CMake 4.0.0 which has dropped support for CMake < 3.5.

## Changes

Intermediary `zlib` versions (1.3.0 and 1.3.1) only contain fixes.
Intermediary `zstd` versions (1.5.3 through 1.5.7) contain both fixes/QoL and performance improvements.
No breaking changes are introduced by neither updates.

Links to the [zlib commit](https://github.com/madler/zlib/tree/51b7f2abdade71cd9bb0e7a373ef2610ec6f9daf) and [zstd commit](https://github.com/facebook/zstd/tree/f8745da6ff1ad1e7bab384bd1f9d742439278e99).
