### PR TITLE
Added RISC-V Vector Support for selected functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,27 @@ message(STATUS "Build type (CMAKE_BUILD_TYPE): ${CMAKE_BUILD_TYPE}")
 
 project(SEAL VERSION 4.1.2 LANGUAGES CXX C)
 
+# Define RISCV as an option
+option(RISCVRVV "Enable RISC-V RVV extension support" OFF)
+
+# Check if RISCV system
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "riscv")
+    message(STATUS "Detected RISC-V architecture. Adding custom flags...")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
+    # If RISCV is enabled (RISCVRVV=ON)
+    if(RISCVRVV)
+        message(STATUS "RISC-V RVV flag detected. Adding rv64gcv flags.")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=rv64gcv -mabi=lp64d")
+    else()
+        # If not enabled
+        message(STATUS "RISC-V RVV flag not detected. Adding rv64gc flags.")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=rv64gc -mabi=lp64d")
+    endif()
+endif()
+
+# Print all flags
+message(STATUS "Final CMake CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
+
 ########################
 # Global configuration #
 ########################

--- a/native/src/seal/util/dwthandler.h
+++ b/native/src/seal/util/dwthandler.h
@@ -11,6 +11,11 @@
 #include "seal/util/uintarithsmallmod.h"
 #include "seal/util/uintcore.h"
 #include <stdexcept>
+#ifdef __riscv_vector
+#include <riscv_vector.h>
+#endif
+
+using namespace std;
 
 namespace seal
 {
@@ -23,6 +28,13 @@ namespace seal
         class Arithmetic
         {
         public:
+            #if defined(__riscv_v_intrinsic)
+                vuint64m4_t guard_vector_rvv(const vuint64m4_t in, size_t vl) const;
+                vuint64m4_t add_vector_rvv(const vuint64m4_t a, const vuint64m4_t b, size_t vl) const;
+                vuint64m4_t sub_vector_rvv(const vuint64m4_t a, const vuint64m4_t b, size_t vl) const;
+                vuint64m4_t mul_vector_rvv(const vuint64m4_t a, const uint64_t yquot, const uint64_t yop, size_t vl) const;
+            #endif
+
             ValueType add(const ValueType &a, const ValueType &b) const;
 
             ValueType sub(const ValueType &a, const ValueType &b) const;
@@ -91,6 +103,202 @@ namespace seal
             @param[roots] powers of a root in bit-reversed order
             @param[scalar] an optional scalar that is multiplied to all output values
             */
+            #if defined(__riscv_v_intrinsic)
+
+            void transform_to_rev_rvv( ValueType *values, int log_n, const RootType *roots, const ScalarType *scalar = nullptr) const
+            {
+                // constant transform size
+                size_t n = size_t(1) << log_n;
+                // registers to hold temporary values
+                RootType r;
+                ValueType u;
+                ValueType v;
+                // pointers for faster indexing
+                ValueType *x = nullptr;
+                ValueType *y = nullptr;
+                // variables for indexing
+                std::size_t gap = n >> 1;
+                std::size_t m = 1;
+
+                
+                for (; m < (n >> 1); m <<= 1)
+                    {
+                        std::size_t offset = 0;
+                        for (size_t i = 0; i < m; i++) {
+                            r = *++roots;
+                            x = values + offset;
+                            y = x + gap;
+                    
+                            size_t processed = 0;
+                            
+                            while (processed < gap) {
+                                
+                                size_t vl = __riscv_vsetvl_e64m4(gap - processed);
+                                vuint64m4_t vx = __riscv_vle64_v_u64m4(x + processed, vl);
+                                vuint64m4_t vy = __riscv_vle64_v_u64m4(y + processed, vl);
+                                // Guard vector (reduce vx elements >= 2*modulus)
+                                vuint64m4_t vu = arithmetic_.guard_vector_rvv(vx, vl);        
+                                // Multiply vy by root quotient modulo root operand
+                                vuint64m4_t vv = arithmetic_.mul_vector_rvv(vy, r.quotient, r.operand, vl);             
+                                // Add vu + vmul → vx
+                                vuint64m4_t vadd = arithmetic_.add_vector_rvv(vu, vv, vl);
+                                // Subtract vu - vmul modulo root operand → vy
+                                vuint64m4_t vsub = arithmetic_.sub_vector_rvv(vu, vv, vl);
+                                // Store results
+                                __riscv_vse64_v_u64m4(x + processed, vadd, vl);
+                                __riscv_vse64_v_u64m4(y + processed, vsub, vl);
+                                                                
+                                processed += vl;
+                            }
+                    
+                            offset += gap << 1;
+                        }
+                        gap >>= 1;
+                    }
+                 if (scalar != nullptr)
+                {
+                    RootType scaled_r;
+                    for (std::size_t i = 0; i < m; i++)
+                    {
+                        r = *++roots;
+                        scaled_r = arithmetic_.mul_root_scalar(r, *scalar);
+                        u = arithmetic_.mul_scalar(arithmetic_.guard(values[0]), *scalar);
+                        v = arithmetic_.mul_root(values[1], scaled_r);
+                        values[0] = arithmetic_.add(u, v);
+                        values[1] = arithmetic_.sub(u, v);
+                        values += 2;
+                    }
+                }
+                else
+                {
+                    for (std::size_t i = 0; i < m; i++)
+                    {
+                        r = *++roots;
+                        u = arithmetic_.guard(values[0]);
+                        v = arithmetic_.mul_root(values[1], r);
+                        values[0] = arithmetic_.add(u, v);
+                        values[1] = arithmetic_.sub(u, v);
+                        values += 2;
+                    }
+                }
+            }
+              void transform_from_rev_rvv( ValueType *values, int log_n, const RootType *roots, const ScalarType *scalar = nullptr) const{
+                    // constant transform size
+                    size_t n = size_t(1) << log_n;
+                // registers to hold temporary values
+                    RootType r;
+                    ValueType u;
+                    ValueType v;
+                    // pointers for faster indexing
+                    ValueType *x = nullptr;
+                    ValueType *y = nullptr;
+                    // variables for indexing
+                    std::size_t gap = 1;
+                    std::size_t m = n >> 1;
+                  
+                   
+                    for (; m > 1; m >>= 1)
+                    {
+                        std::size_t offset = 0;
+                        for (std::size_t i = 0; i < m; i++)
+                        {
+                            r = *++roots;
+                            x = values + offset;
+                            y = x + gap;
+
+                            std::size_t processed = 0;
+                            
+                            while (processed < gap){
+                                size_t vl = __riscv_vsetvl_e64m4(gap - processed);
+                                vuint64m4_t vx = __riscv_vle64_v_u64m4(x + processed, vl);
+                                vuint64m4_t vy = __riscv_vle64_v_u64m4(y + processed, vl);
+                                vuint64m4_t vadd = arithmetic_.add_vector_rvv(vx, vy, vl);
+                                vadd = arithmetic_.guard_vector_rvv(vadd, vl);
+                                vuint64m4_t vsub = arithmetic_.sub_vector_rvv(vx, vy, vl);
+                                vuint64m4_t vmul = arithmetic_.mul_vector_rvv(vsub, r.quotient, r.operand, vl);
+                                __riscv_vse64_v_u64m4(x + processed, vadd, vl);
+                                __riscv_vse64_v_u64m4(y + processed, vmul, vl);
+                                processed += vl;
+                            }
+                            offset += gap << 1;
+                            }
+
+                        gap <<= 1;
+                        }
+
+                    if (scalar != nullptr)
+                    {
+                        r = *++roots;
+                        RootType scaled_r = arithmetic_.mul_root_scalar(r, *scalar);
+                        x = values;
+                        y = x + gap;
+                        if (gap < 4)
+                        {
+                            for (std::size_t j = 0; j < gap; j++)
+                            {
+                                u = arithmetic_.guard(*x);
+                                v = *y;
+                                *x++ = arithmetic_.mul_scalar(arithmetic_.guard(arithmetic_.add(u, v)), *scalar);
+                                *y++ = arithmetic_.mul_root(arithmetic_.sub(u, v), scaled_r);
+                            }
+                        }
+                        else
+                        {
+                            for (std::size_t j = 0; j < gap; j += 4)
+                            {
+                                u = arithmetic_.guard(*x);
+                                v = *y;
+                                *x++ = arithmetic_.mul_scalar(arithmetic_.guard(arithmetic_.add(u, v)), *scalar);
+                                *y++ = arithmetic_.mul_root(arithmetic_.sub(u, v), scaled_r);
+    
+                                u = arithmetic_.guard(*x);
+                                v = *y;
+                                *x++ = arithmetic_.mul_scalar(arithmetic_.guard(arithmetic_.add(u, v)), *scalar);
+                                *y++ = arithmetic_.mul_root(arithmetic_.sub(u, v), scaled_r);
+    
+                                u = arithmetic_.guard(*x);
+                                v = *y;
+                                *x++ = arithmetic_.mul_scalar(arithmetic_.guard(arithmetic_.add(u, v)), *scalar);
+                                *y++ = arithmetic_.mul_root(arithmetic_.sub(u, v), scaled_r);
+    
+                                u = arithmetic_.guard(*x);
+                                v = *y;
+                                *x++ = arithmetic_.mul_scalar(arithmetic_.guard(arithmetic_.add(u, v)), *scalar);
+                                *y++ = arithmetic_.mul_root(arithmetic_.sub(u, v), scaled_r);
+                                }
+                            }
+                        }
+                    else
+                    {
+                            r = *++roots;
+                            x = values;
+                            y = x + gap;
+                        
+                            size_t processed = 0;
+                            
+                            while (processed < gap)
+                            {
+                                size_t vl = __riscv_vsetvl_e64m4(gap - processed);
+                                vuint64m4_t vx = __riscv_vle64_v_u64m4(x + processed, vl);
+                                vuint64m4_t vy = __riscv_vle64_v_u64m4(y + processed, vl);
+                                // u + v
+                                vuint64m4_t vadd = arithmetic_.add_vector_rvv(vx, vy, vl);
+                                // Guard the addition result
+                                vuint64m4_t vguard_add = arithmetic_.guard_vector_rvv(vadd, vl);
+                                // u - v
+                                vuint64m4_t vsub = arithmetic_.sub_vector_rvv(vx, vy, vl);
+                                // Multiply by root
+                                vuint64m4_t vmul_y = arithmetic_.mul_vector_rvv(vsub, r.quotient, r.operand, vl);
+                                // Store back
+                                __riscv_vse64_v_u64m4(x + processed, vguard_add, vl);
+                                __riscv_vse64_v_u64m4(y + processed, vmul_y, vl);
+                            
+                                processed += vl;
+                            }
+                        }
+                    }
+            #endif
+
             void transform_to_rev(
                 ValueType *values, int log_n, const RootType *roots, const ScalarType *scalar = nullptr) const
             {
@@ -107,60 +315,60 @@ namespace seal
                 std::size_t gap = n >> 1;
                 std::size_t m = 1;
 
-                for (; m < (n >> 1); m <<= 1)
-                {
-                    std::size_t offset = 0;
-                    if (gap < 4)
+                    for (; m < (n >> 1); m <<= 1)
                     {
-                        for (std::size_t i = 0; i < m; i++)
+                        std::size_t offset = 0;
+                        if (gap < 4)
                         {
-                            r = *++roots;
-                            x = values + offset;
-                            y = x + gap;
-                            for (std::size_t j = 0; j < gap; j++)
+                            for (std::size_t i = 0; i < m; i++)
                             {
-                                u = arithmetic_.guard(*x);
-                                v = arithmetic_.mul_root(*y, r);
-                                *x++ = arithmetic_.add(u, v);
-                                *y++ = arithmetic_.sub(u, v);
+                                r = *++roots;
+                                x = values + offset;
+                                y = x + gap;
+                                for (std::size_t j = 0; j < gap; j++)
+                                {
+                                    u = arithmetic_.guard(*x);
+                                    v = arithmetic_.mul_root(*y, r);
+                                    *x++ = arithmetic_.add(u, v);
+                                    *y++ = arithmetic_.sub(u, v);
+                                }
+                                offset += gap << 1;
                             }
-                            offset += gap << 1;
                         }
-                    }
-                    else
-                    {
-                        for (std::size_t i = 0; i < m; i++)
+                        else
                         {
-                            r = *++roots;
-                            x = values + offset;
-                            y = x + gap;
-                            for (std::size_t j = 0; j < gap; j += 4)
+                            for (std::size_t i = 0; i < m; i++)
                             {
-                                u = arithmetic_.guard(*x);
-                                v = arithmetic_.mul_root(*y, r);
-                                *x++ = arithmetic_.add(u, v);
-                                *y++ = arithmetic_.sub(u, v);
-
-                                u = arithmetic_.guard(*x);
-                                v = arithmetic_.mul_root(*y, r);
-                                *x++ = arithmetic_.add(u, v);
-                                *y++ = arithmetic_.sub(u, v);
-
-                                u = arithmetic_.guard(*x);
-                                v = arithmetic_.mul_root(*y, r);
-                                *x++ = arithmetic_.add(u, v);
-                                *y++ = arithmetic_.sub(u, v);
-
-                                u = arithmetic_.guard(*x);
-                                v = arithmetic_.mul_root(*y, r);
-                                *x++ = arithmetic_.add(u, v);
-                                *y++ = arithmetic_.sub(u, v);
+                                r = *++roots;
+                                x = values + offset;
+                                y = x + gap;
+                                for (std::size_t j = 0; j < gap; j += 4)
+                                {
+                                    u = arithmetic_.guard(*x);
+                                    v = arithmetic_.mul_root(*y, r);
+                                    *x++ = arithmetic_.add(u, v);
+                                    *y++ = arithmetic_.sub(u, v);
+    
+                                    u = arithmetic_.guard(*x);
+                                    v = arithmetic_.mul_root(*y, r);
+                                    *x++ = arithmetic_.add(u, v);
+                                    *y++ = arithmetic_.sub(u, v);
+    
+                                    u = arithmetic_.guard(*x);
+                                    v = arithmetic_.mul_root(*y, r);
+                                    *x++ = arithmetic_.add(u, v);
+                                    *y++ = arithmetic_.sub(u, v);
+    
+                                    u = arithmetic_.guard(*x);
+                                    v = arithmetic_.mul_root(*y, r);
+                                    *x++ = arithmetic_.add(u, v);
+                                    *y++ = arithmetic_.sub(u, v);
+                                }
+                                offset += gap << 1;
                             }
-                            offset += gap << 1;
                         }
+                        gap >>= 1;
                     }
-                    gap >>= 1;
-                }
 
                 if (scalar != nullptr)
                 {
@@ -199,6 +407,7 @@ namespace seal
             @param[roots] powers of a root in scrambled order
             @param[scalar] an optional scalar that is multiplied to all output values
             */
+
             void transform_from_rev(
                 ValueType *values, int log_n, const RootType *roots, const ScalarType *scalar = nullptr) const
             {


### PR DESCRIPTION
**Description**

This pull request introduces RISC-V Vector (RVV 1.0) support for selected functions, extending the project with vectorized implementations inspired by my research. The goal is to leverage the RVV extension in order to improve performance in computationally intensive routines. The changes are based on my findings, which explored the acceleration of homomorphic encryption primitives on RISC-V processors using the Vector Extension. It is focused on BFV, the general techniques of instruction fusion and vectorization proved effective in accelerating arithmetic kernels.

**Changes**

- Added RVV intrinsics for selected functions.
- Introduced vectorized code paths while preserving scalar fallbacks for non-RVV targets.
- Optimized arithmetic routines to reduce instruction overhead and exploit data parallelism.
- Enable compiler optimizations (-O3)

**Results**

According to  experiments in a Gem5 simulated RISC-V system, vectorization can provide up to 13× theoretical speedup, though practical results vary depending on workload. This PR lays the groundwork for further improvements by integrating RVV support directly into the codebase.


The RISC-V Vector intrinsics support is added for the following functions

```
divide_uint128_uint64_inplace_generic
multiply_poly_scalar_coeffmod
dyadic_product_coeffmod
dot_product_mod
transform_to_rev
transform_from_rev
```
[Compilation]

Ubuntu: 24.04
Build environment:
- Target: riscv64-linux-gnu (glibc)
- GCC version: 13.3.0

To compile the project with RISC-V RVV extension support enabled, make sure to enable the appropriate target flags during the build stage.

Directly on RISC-V cpu

`cmake -S . -B build  -DRISCVRVV=ON`

For Cross Compilation

`cmake -S . -B build  -DRISCVRVV=ON  -DCMAKE_C_COMPILER=riscv64-linux-gnu-gcc  -DCMAKE_CXX_COMPILER=riscv64-linux-gnu-g++`


**Notes**

- Code has been tested on an RVV-enabled RISC-V simulator and verified against baseline results.
- Future work could extend RVV coverage to additional kernels and explore deeper pipeline optimizations.