### PR TITLE
[codex] fix: avoid returning temporary IterTuple refs

### DIFF
--- a/native/src/seal/util/iterator.h
+++ b/native/src/seal/util/iterator.h
@@ -1846,7 +1846,7 @@ namespace seal
             template <typename... Ts>
             IterTuple(const std::tuple<Ts...> &tp)
                 : IterTuple(seal_apply(
-                      [](auto &&... args) -> IterTuple { return { std::forward<decltype(args)>(args)... }; },
+                      [](auto &&... args) -> self_type { return self_type(std::forward<decltype(args)>(args)...); },
                       std::forward<decltype(tp)>(tp)))
             {
                 static_assert(
@@ -1856,7 +1856,7 @@ namespace seal
             template <typename... Ts>
             IterTuple(std::tuple<Ts...> &&tp)
                 : IterTuple(seal_apply(
-                      [](auto &&... args) -> IterTuple && { return { std::forward<decltype(args)>(args)... }; },
+                      [](auto &&... args) -> self_type { return self_type(std::forward<decltype(args)>(args)...); },
                       std::forward<decltype(tp)>(tp)))
             {
                 static_assert(

--- a/native/tests/seal/util/iterator.cpp
+++ b/native/tests/seal/util/iterator.cpp
@@ -474,6 +474,15 @@ namespace sealtest
             ASSERT_EQ(1, *get<0>(s));
             ASSERT_EQ(0, *get<1>(s));
 
+            auto tuple_source = make_tuple(2, 3);
+            IterTuple<SeqIter<int>, SeqIter<int>> from_tuple(tuple_source);
+            ASSERT_EQ(2, *get<0>(from_tuple));
+            ASSERT_EQ(3, *get<1>(from_tuple));
+
+            IterTuple<SeqIter<int>, SeqIter<int>> from_moved_tuple(make_tuple(4, 5));
+            ASSERT_EQ(4, *get<0>(from_moved_tuple));
+            ASSERT_EQ(5, *get<1>(from_moved_tuple));
+
             // Get
             ASSERT_EQ(0, get<0>(IterTuple<SeqIter<int>, SeqIter<int>>{ 0, 1 }));
             ASSERT_EQ(1, get<1>(IterTuple<SeqIter<int>, SeqIter<int>>{ 0, 1 }));


### PR DESCRIPTION
## Summary
- replace the `IterTuple` tuple-constructor lambdas with explicit `self_type(...)` construction
- add regression coverage for tuple lvalue and moved-tuple construction in `IteratorTest`

## Root Cause
The tuple constructor path in `IterTuple` returned `IterTuple &&` from a temporary braced construction. Under `_GLIBCXX_DEBUG` this can trigger `returning reference to temporary` diagnostics and produce incorrect behavior for tuple-based construction.

## Validation
- reproduced the issue with a focused `_GLIBCXX_DEBUG` smoke test against the pre-fix code
- confirmed the pre-fix code fails with `-Werror=return-local-addr`
- confirmed the patched code compiles cleanly under the same smoke test and the runtime smoke test exits successfully
- added native iterator regression coverage for both tuple lvalue and moved-tuple construction
