### PR TITLE
[codex] tests: use explicit chrono duration in locks test

### DIFF
--- a/native/tests/seal/util/locks.cpp
+++ b/native/tests/seal/util/locks.cpp
@@ -3,6 +3,7 @@
 
 #include "seal/util/locks.h"
 #include <atomic>
+#include <chrono>
 #include <thread>
 #include "gtest/gtest.h"
 
@@ -204,7 +205,7 @@ namespace sealtest
                 writer1->acquire_write();
                 while (!should_unlock1)
                 {
-                    this_thread::sleep_for(10ms);
+                    this_thread::sleep_for(std::chrono::milliseconds(10));
                 }
                 writer1->release();
             });
@@ -223,7 +224,7 @@ namespace sealtest
                 writer2->acquire_write();
                 while (!should_unlock2)
                 {
-                    this_thread::sleep_for(10ms);
+                    this_thread::sleep_for(std::chrono::milliseconds(10));
                 }
                 writer2->release();
             });


### PR DESCRIPTION
## Summary
- add `<chrono>` to the locks unit test
- replace `10ms` chrono literals with `std::chrono::milliseconds(10)`

## Why
The locks unit test used `10ms` without bringing the chrono literal namespace into scope. On newer MSVC toolchains this breaks the native test build even though the test logic itself is fine.

## Impact
This is a test-only compatibility fix. It does not change production code.

## Validation
- configured a native test build with `SEAL_BUILD_TESTS=ON`
- built `sealtest`
- ran `sealtest`
- result: 276 tests passed
