### PR TITLE
fix: prevent OOB read in C API header validation (#737)

### DIFF
--- a/native/src/seal/c/serialization.cpp
+++ b/native/src/seal/c/serialization.cpp
@@ -51,6 +51,7 @@ SEAL_C_FUNC Serialization_IsCompatibleVersion(uint8_t *headerptr, uint64_t size,
     if (size != static_cast<uint64_t>(sizeof(Serialization::SEALHeader)))
     {
         *result = false;
+        return S_OK;
     }
 
     Serialization::SEALHeader header;
@@ -68,6 +69,7 @@ SEAL_C_FUNC Serialization_IsValidHeader(uint8_t *headerptr, uint64_t size, bool 
     if (size != static_cast<uint64_t>(sizeof(Serialization::SEALHeader)))
     {
         *result = false;
+        return S_OK;
     }
 
     Serialization::SEALHeader header;


### PR DESCRIPTION
## Summary
Fixes out-of-bounds read in `Serialization_IsCompatibleVersion` and `Serialization_IsValidHeader` (`native/src/seal/c/serialization.cpp`).

Both functions set `*result = false` when the caller-provided `size` does not match `sizeof(SEALHeader)`, but they do not return — execution falls through to `memcpy(&header, headerptr, sizeof(SEALHeader))`. A caller passing e.g. `size = 1` with a 1-byte allocation triggers an OOB read of up to `sizeof(SEALHeader)` bytes across the FFI boundary, producing information disclosure / DoS.

## Fix
Return `S_OK` immediately after flagging the mismatch so the `memcpy` never executes on an undersized buffer. Preserves the existing contract (function returns `S_OK`, `*result == false`).

## Testing
- Existing `SerializationTest` suite passes (`sealtest --gtest_filter=*Serialization*`).
- Full `sealtest` suite shows no new failures attributable to this diff. One pre-existing macOS-specific ASan finding in `RandomGenerator.UniformRandomGeneratorInfoSaveLoad` (`memset_s` use-after-poison in `libsystem_c`) is unrelated and reproducible on unpatched `main`.
- No C API test harness exists in `native/tests/`; this change is a strict tightening of an error path.

## Closes
#737