### PR TITLE
Fix documentation typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Contact [opencode@microsoft.com](mailto:opencode@microsoft.com) for any addition
 
 ### Pull Requests
 
-Submit pull requrests to **branch *contrib***.
+Submit pull requests to **branch *contrib***.
 Pull requests to any other branch will not be accepted.
 
 When you submit a pull request, a CLA bot will automatically determine whether you need to **provide a CLA** and decorate the PR appropriately (e.g., status check, comment).
@@ -23,5 +23,5 @@ A script `tools/scripts/clang-format-all.sh` is provided to easily format all C+
 To ensure the code is properly formatted before making a pull request, we highly recommend using [pre-commit](https://pre-commit.com/).
 Note that the repository includes a `.pre-commit-config.yaml` that describes the appropriate formatting checks.
 
-Documentation are mostly written in GitHub-flavored Markdown.
+Documentation is mostly written in GitHub-flavored Markdown.
 A line break is required after each full sentence.

--- a/README.md
+++ b/README.md
@@ -138,9 +138,9 @@ ZLIB and Zstandard are widely used compression libraries. Microsoft SEAL can opt
 One may ask how compression can help when ciphertext and key data is supposed to be indistinguishable from random.
 In Microsoft SEAL `Ciphertext` objects consist of a large number of integers modulo specific prime numbers (`coeff_modulus` primes).
 When using the CKKS scheme in particular, these prime numbers can be quite small (e.g., 30 bits), but the data is nevertheless serialized as 64-bit integers.
-Therefore, it is not uncommon that almost half of the ciphertext bytes are zeros, and applying a general-purpose compression algorithm is a convenient way of getting rid this wasted space.
+Therefore, it is not uncommon that almost half of the ciphertext bytes are zeros, and applying a general-purpose compression algorithm is a convenient way of getting rid of this wasted space.
 The BFV scheme benefits typically less from this technique, because the prime numbers used for the `coeff_modulus` encryption parameter tend to be larger, and integers modulo these prime numbers fill more of each 64-bit word.
-Compressed serialization can be applied to any serializable Microsoft SEAL object &ndash; not just to `Ciphertext` and keys .
+Compressed serialization can be applied to any serializable Microsoft SEAL object &ndash; not just to `Ciphertext` and keys.
 
 If Microsoft SEAL is compiled with ZLIB or Zstandard support, compression will automatically be used for serialization; see `Serialization::compr_mode_default` in [native/src/seal/serialization.h](native/src/seal/serialization.h).
 However, it is always possible to explicitly pass `compr_mode_type::none` to serialization methods to disable compression.

--- a/dotnet/src/BatchEncoder.cs
+++ b/dotnet/src/BatchEncoder.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Research.SEAL
         /// </remarks>
         /// <param name="values">The matrix of integers modulo plaintext modulus to batch</param>
         /// <param name="destination">The plaintext polynomial to overwrite with the result</param>
-        /// <exception cref="ArgumentNullException">if either values or destionation are null</exception>
+        /// <exception cref="ArgumentNullException">if either values or destination are null</exception>
         /// <exception cref="ArgumentException">if values is too large</exception>
         public void Encode(IEnumerable<long> values, Plaintext destination)
         {
@@ -151,7 +151,7 @@ namespace Microsoft.Research.SEAL
         /// <param name="plain">The plaintext polynomial to unbatch</param>
         /// <param name="destination">The matrix to be overwritten with the values in the slots</param>
         /// <param name="pool">The MemoryPoolHandle pointing to a valid memory pool</param>
-        /// <exception cref="ArgumentNullException">if either plain or destionation are null</exception>
+        /// <exception cref="ArgumentNullException">if either plain or destination are null</exception>
         /// <exception cref="ArgumentException">if plain is not valid for the encryption parameters</exception>
         /// <exception cref="ArgumentException">if plain is in NTT form</exception>
         /// <exception cref="ArgumentException">if pool is uninitialized</exception>

--- a/dotnet/src/CKKSEncoder.cs
+++ b/dotnet/src/CKKSEncoder.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Research.SEAL
         /// <param name="scale">Scaling parameter defining encoding precision</param>
         /// <param name="destination">The plaintext polynomial to overwrite with the result</param>
         /// <param name="pool">The MemoryPoolHandle pointing to a valid memory pool</param>
-        /// <exception cref="ArgumentNullException">if either values, parmsId or destionation are null.</exception>
+        /// <exception cref="ArgumentNullException">if either values, parmsId or destination are null.</exception>
         /// <exception cref="ArgumentException">if values has invalid size</exception>
         /// <exception cref="ArgumentException">if parmsId is not valid for the encryption
         /// parameters </exception>
@@ -112,7 +112,7 @@ namespace Microsoft.Research.SEAL
         /// <param name="scale">Scaling parameter defining encoding precision</param>
         /// <param name="destination">The plaintext polynomial to overwrite with the result</param>
         /// <param name="pool">The MemoryPoolHandle pointing to a valid memory pool</param>
-        /// <exception cref="ArgumentNullException">if either values, parmsId or destionation are null.</exception>
+        /// <exception cref="ArgumentNullException">if either values, parmsId or destination are null.</exception>
         /// <exception cref="ArgumentException">if values has invalid size</exception>
         /// <exception cref="ArgumentException">if parmsId is not valid for the encryption
         /// parameters </exception>
@@ -159,7 +159,7 @@ namespace Microsoft.Research.SEAL
         /// <param name="scale">Scaling parameter defining encoding precision</param>
         /// <param name="destination">The plaintext polynomial to overwrite with the result</param>
         /// <param name="pool">The MemoryPoolHandle pointing to a valid memory pool</param>
-        /// <exception cref="ArgumentNullException">if either values or destionation are null.</exception>
+        /// <exception cref="ArgumentNullException">if either values or destination are null.</exception>
         /// <exception cref="ArgumentException">if values has invalid size</exception>
         /// <exception cref="ArgumentException">if scale is not strictly positive</exception>
         /// <exception cref="ArgumentException">if encoding is too large for the encryption
@@ -185,7 +185,7 @@ namespace Microsoft.Research.SEAL
         /// <param name="scale">Scaling parameter defining encoding precision</param>
         /// <param name="destination">The plaintext polynomial to overwrite with the result</param>
         /// <param name="pool">The MemoryPoolHandle pointing to a valid memory pool</param>
-        /// <exception cref="ArgumentNullException">if either values or destionation are null.</exception>
+        /// <exception cref="ArgumentNullException">if either values or destination are null.</exception>
         /// <exception cref="ArgumentException">if values has invalid size</exception>
         /// <exception cref="ArgumentException">if scale is not strictly positive</exception>
         /// <exception cref="ArgumentException">if encoding is too large for the encryption
@@ -318,7 +318,7 @@ namespace Microsoft.Research.SEAL
         /// <param name="parmsId">parmsId determining the encryption parameters to be used
         /// by the result plaintext</param>
         /// <param name="destination">The plaintext polynomial to overwrite with the result</param>
-        /// <exception cref="ArgumentNullException">if either parmsId or destionation are null</exception>
+        /// <exception cref="ArgumentNullException">if either parmsId or destination are null</exception>
         /// <exception cref="ArgumentException">if parmsId is not valid for the encryption
         /// parameters </exception>
         public void Encode(long value, ParmsId parmsId, Plaintext destination)


### PR DESCRIPTION
## Summary

Fixes several documentation typos in README, CONTRIBUTING, and .NET XML comments.

## Testing

Documentation-only change; no tests run.