### PR TITLE
Add bit-packing serialization mode (compr_mode_type::bitpack)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # List of Changes
 
+## Unreleased
+
+- Added a new serialization mode `compr_mode_type::bitpack` (native) or `ComprModeType.BitPack` (dotnet) that re-encodes each block of 64-bit words using only as many bits per word as the largest word in the block requires.
+Ciphertext and key data store integers modulo primes much smaller than the word size, and their significant bits are close to uniformly random, so bit-packing typically produces smaller output than ZLIB or Zstandard, which cannot remove partial bytes.
+The mode is always available (it requires no external dependency) and loading is streamed with bounded memory use, like compressed loading.
+The default compression mode is unchanged, and the wire format of all existing modes is unchanged; objects serialized with bit-packing cannot be loaded by earlier versions of Microsoft SEAL.
+
 ## Version 4.4.2
 
 - Fixed null-pointer dereferences in the C API ([issue #752](https://github.com/microsoft/SEAL/issues/752)): `Plaintext_Set4`, `CKKSEncoder_Encode1`, and `CKKSEncoder_Encode2` validated the target object but not the caller-provided input array, and crashed instead of returning `E_POINTER`.

--- a/dotnet/src/Serialization.cs
+++ b/dotnet/src/Serialization.cs
@@ -15,6 +15,14 @@ namespace Microsoft.Research.SEAL
     /// a large number of zero bytes in the output. Any compression algorithm should
     /// be able to clean up these zero bytes and hence compress both ciphertext and
     /// key data.
+    ///
+    /// Alternatively, ComprModeType.BitPack re-encodes each block of 64-bit words
+    /// using only as many bits per word as the largest word in the block requires,
+    /// discarding exactly the always-zero high bits. The significant bits of
+    /// ciphertext and key data are close to uniformly random and hence essentially
+    /// incompressible, so bit-packing typically produces smaller output than a
+    /// general-purpose compressor, which cannot remove partial bytes. Unlike ZLIB
+    /// and Zstandard, bit-packing performs no integrity checking of the data.
     /// </summary>
     public enum ComprModeType : byte
     {
@@ -25,7 +33,10 @@ namespace Microsoft.Research.SEAL
         ZLIB = 1,
 
         /// <summary>Use Zstandard compression.</summary>
-        ZSTD = 2
+        ZSTD = 2,
+
+        /// <summary>Use bit-packing of 64-bit words.</summary>
+        BitPack = 3
     }
 
     /// <summary>Class to provide functionality for serialization.</summary>

--- a/dotnet/tests/CiphertextTests.cs
+++ b/dotnet/tests/CiphertextTests.cs
@@ -222,6 +222,44 @@ namespace SEALNetTest
         }
 
         [TestMethod]
+        public void BFVBitPackSaveLoadTest()
+        {
+            SEALContext context = GlobalContext.BFVContext;
+            KeyGenerator keygen = new KeyGenerator(context);
+            keygen.CreatePublicKey(out PublicKey publicKey);
+
+            Encryptor encryptor = new Encryptor(context, publicKey);
+            Plaintext plain = new Plaintext("2x^3 + 4x^2 + 5x^1 + 6");
+            Ciphertext cipher = new Ciphertext();
+
+            encryptor.Encrypt(plain, cipher);
+
+            Ciphertext loaded = new Ciphertext();
+            long saveSize = 0;
+
+            using (MemoryStream mem = new MemoryStream())
+            {
+                saveSize = cipher.Save(mem, ComprModeType.BitPack);
+
+                mem.Seek(offset: 0, loc: SeekOrigin.Begin);
+
+                loaded.Load(context, mem);
+            }
+
+            Assert.IsTrue(ValCheck.IsValidFor(loaded, context));
+
+            ulong ulongCount = cipher.Size * cipher.PolyModulusDegree * cipher.CoeffModulusSize;
+            for (ulong i = 0; i < ulongCount; i++)
+            {
+                Assert.AreEqual(cipher[i], loaded[i]);
+            }
+
+            // The coefficients are uniformly random modulo the coefficient modulus primes, which are well under
+            // 64 bits, so packing each 64-bit word to its significant bits must beat the unpacked size.
+            Assert.IsTrue(saveSize < cipher.SaveSize(ComprModeType.None));
+        }
+
+        [TestMethod]
         public void BGVSaveLoadTest()
         {
             SEALContext context = GlobalContext.BGVContext;

--- a/dotnet/tests/SerializationTests.cs
+++ b/dotnet/tests/SerializationTests.cs
@@ -28,7 +28,9 @@ namespace SEALNetTest
             invalidHeader.VersionMajor = 0x02;
             Assert.IsFalse(Serialization.IsValidHeader(invalidHeader));
             invalidHeader.VersionMajor = SEALVersion.Major;
-            invalidHeader.ComprMode = (ComprModeType)0x03;
+            invalidHeader.ComprMode = ComprModeType.BitPack;
+            Assert.IsTrue(Serialization.IsValidHeader(invalidHeader));
+            invalidHeader.ComprMode = (ComprModeType)0x04;
             Assert.IsFalse(Serialization.IsValidHeader(invalidHeader));
         }
 

--- a/native/src/seal/serialization.cpp
+++ b/native/src/seal/serialization.cpp
@@ -4,6 +4,7 @@
 #include "seal/dynarray.h"
 #include "seal/memorymanager.h"
 #include "seal/serialization.h"
+#include "seal/util/bitpack.h"
 #include "seal/util/common.h"
 #include "seal/util/streambuf.h"
 #include "seal/util/ztools.h"
@@ -99,6 +100,9 @@ namespace seal
         case compr_mode_type::zlib:
             return ztools::zlib_deflate_size_bound(in_size);
 #endif
+        case compr_mode_type::bitpack:
+            return bitpack::bitpack_size_bound(in_size);
+
         case compr_mode_type::none:
             // No compression
             return in_size;
@@ -315,6 +319,29 @@ namespace seal
                 break;
             }
 #endif
+            case compr_mode_type::bitpack:
+            {
+                // First save_members to a temporary byte stream; set the size of the temporary stream to be right from
+                // the start to avoid extra reallocs.
+                SafeByteBuffer safe_buffer(
+                    bitpack::bitpack_size_bound(raw_size - static_cast<streamoff>(sizeof(SEALHeader))), clear_buffers);
+                iostream temp_stream(&safe_buffer);
+                temp_stream.exceptions(ios_base::badbit | ios_base::failbit);
+                save_members(temp_stream);
+
+                auto safe_pool(MemoryManager::GetPool(mm_prof_opt::mm_force_new, clear_buffers));
+
+                // Create temporary aliasing DynArray to wrap safe_buffer
+                DynArray<seal_byte> safe_buffer_array(
+                    Pointer<seal_byte>::Aliasing(safe_buffer.data()), safe_buffer.size(),
+                    static_cast<size_t>(temp_stream.tellp()), false, safe_pool);
+
+                // After bit-packing, write_header_pack_buffer will write the final size to the given header and
+                // write the header to stream, before writing the bit-packed output.
+                bitpack::bitpack_write_header_pack_buffer(
+                    safe_buffer_array, reinterpret_cast<void *>(&header), stream, safe_pool);
+                break;
+            }
             default:
                 throw invalid_argument("unsupported compression mode");
             }
@@ -514,6 +541,45 @@ namespace seal
                 break;
             }
 #endif
+            case compr_mode_type::bitpack:
+            {
+                // header.size counts the whole object including the header, so the packed payload is exactly
+                // header.size - sizeof(SEALHeader). Computing it directly keeps it correct on non-seekable streams,
+                // where tellg() returns -1 and cannot be used to measure the header.
+                auto packed_size = header.size - static_cast<uint64_t>(sizeof(SEALHeader));
+
+                auto safe_pool = MemoryManager::GetPool(mm_prof_opt::mm_force_new, clear_buffers);
+
+                // Unpack on demand directly into the parser rather than decoding the entire payload up front. This
+                // bounds memory use during loading to what the parser actually reads, so a hostile size claim in the
+                // packed data cannot drive an unbounded allocation.
+                streamoff packed_remaining = 0;
+                {
+                    auto unpack_buffer =
+                        bitpack::make_bitpack_unpack_buffer(stream, safe_cast<streamoff>(packed_size), safe_pool);
+                    istream temp_stream(unpack_buffer.get());
+                    temp_stream.exceptions(ios_base::badbit | ios_base::failbit);
+
+                    load_members(temp_stream, version);
+
+                    if (unpack_buffer->failed())
+                    {
+                        throw logic_error("stream decompression failed");
+                    }
+                    packed_remaining = unpack_buffer->remaining();
+                }
+
+                // The parser may not have pulled the whole packed payload. On a seekable stream, where header.size
+                // was confirmed to fit the available input, skip any remainder so the stream ends exactly at
+                // stream_start_pos + header.size, keeping concatenated objects loadable. On a non-seekable stream
+                // header.size is unverified, so skipping is gated off: an inflated header.size must not drive
+                // stream.ignore() past the real data into an over-read or an indefinite block.
+                if (size_verified && packed_remaining > 0)
+                {
+                    stream.ignore(packed_remaining);
+                }
+                break;
+            }
             default:
                 throw invalid_argument("unsupported compression mode");
             }

--- a/native/src/seal/serialization.h
+++ b/native/src/seal/serialization.h
@@ -19,6 +19,15 @@ namespace seal
     a large number of zero bytes in the output. Any compression algorithm should
     be able to clean up these zero bytes and hence compress both ciphertext and
     key data.
+
+    Alternatively, compr_mode_type::bitpack re-encodes each block of 64-bit
+    words using only as many bits per word as the largest word in the block
+    requires, discarding exactly the always-zero high bits. The significant
+    bits of ciphertext and key data are close to uniformly random and hence
+    essentially incompressible, so bit-packing typically produces smaller
+    output than a general-purpose compressor, which cannot remove partial
+    bytes. Unlike ZLIB and Zstandard, bit-packing performs no integrity
+    checking of the data.
     */
     enum class compr_mode_type : std::uint8_t
     {
@@ -32,6 +41,8 @@ namespace seal
         // Use Zstandard compression
         zstd = 2,
 #endif
+        // Use bit-packing of 64-bit words
+        bitpack = 3,
     };
 
     /**
@@ -109,7 +120,9 @@ namespace seal
 #endif
 #ifdef SEAL_USE_ZSTD
             case static_cast<std::uint8_t>(compr_mode_type::zstd):
+                /* fall through */
 #endif
+            case static_cast<std::uint8_t>(compr_mode_type::bitpack):
                 return true;
             }
             return false;

--- a/native/src/seal/util/CMakeLists.txt
+++ b/native/src/seal/util/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 # Source files in this directory
 set(SEAL_SOURCE_FILES ${SEAL_SOURCE_FILES}
+    ${CMAKE_CURRENT_LIST_DIR}/bitpack.cpp
     ${CMAKE_CURRENT_LIST_DIR}/blake2b.c
     ${CMAKE_CURRENT_LIST_DIR}/blake2xb.c
     ${CMAKE_CURRENT_LIST_DIR}/clipnormal.cpp
@@ -31,6 +32,7 @@ set(SEAL_SOURCE_FILES ${SEAL_SOURCE_FILES}
 # Add header files for installation
 install(
     FILES
+        ${CMAKE_CURRENT_LIST_DIR}/bitpack.h
         ${CMAKE_CURRENT_LIST_DIR}/blake2.h
         ${CMAKE_CURRENT_LIST_DIR}/blake2-impl.h
         ${CMAKE_CURRENT_LIST_DIR}/clang.h

--- a/native/src/seal/util/bitpack.cpp
+++ b/native/src/seal/util/bitpack.cpp
@@ -1,0 +1,359 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#include "seal/serialization.h"
+#include "seal/util/bitpack.h"
+#include "seal/util/common.h"
+#include <algorithm>
+#include <cstring>
+
+using namespace std;
+
+namespace seal
+{
+    namespace util
+    {
+        namespace bitpack
+        {
+            namespace
+            {
+                // Size in bytes of the 64-bit words being packed.
+                constexpr size_t bytes_per_word = sizeof(uint64_t);
+
+                // Slack allowing the packing and unpacking loops to address words through whole-uint64_t reads and
+                // writes near the end of a block without stepping out of bounds.
+                constexpr size_t block_slack = bytes_per_word;
+
+                // Number of whole 64-bit words in a block of block_len bytes read at the given phase.
+                SEAL_NODISCARD inline size_t block_word_count(size_t block_len, size_t phase) noexcept
+                {
+                    return (block_len - phase) / bytes_per_word;
+                }
+
+                // Encoded size in bytes of the body of a block of block_len bytes read at the given phase: the
+                // verbatim phase bytes, the packed words, and the verbatim tail bytes.
+                SEAL_NODISCARD inline size_t block_body_size(size_t block_len, size_t phase, int width) noexcept
+                {
+                    size_t words = block_word_count(block_len, phase);
+                    size_t packed_bytes = (words * static_cast<size_t>(width) + size_t(7)) >> 3;
+                    return block_len - words * bytes_per_word + packed_bytes;
+                }
+            } // namespace
+
+            void bitpack_write_header_pack_buffer(
+                const DynArray<seal_byte> &in, void *header_ptr, ostream &out_stream, MemoryPoolHandle pool)
+            {
+                if (!pool)
+                {
+                    throw invalid_argument("pool is uninitialized");
+                }
+
+                Serialization::SEALHeader &header = *reinterpret_cast<Serialization::SEALHeader *>(header_ptr);
+
+                size_t in_size = in.size();
+                const unsigned char *in_data = reinterpret_cast<const unsigned char *>(in.cbegin());
+
+                // The whole-uint64_t writes below rely on the output being zero-filled (DynArray zero-fills) and on
+                // block_slack bytes of headroom past the size bound.
+                DynArray<seal_byte> out(add_safe(bitpack_size_bound(in_size), block_slack), pool);
+                unsigned char *out_data = reinterpret_cast<unsigned char *>(out.begin());
+
+                // Write the original byte count
+                uint64_t in_size64 = static_cast<uint64_t>(in_size);
+                memcpy(out_data, &in_size64, bytes_per_word);
+                size_t out_pos = bytes_per_word;
+
+                for (size_t block_start = 0; block_start < in_size;)
+                {
+                    size_t block_len = min(bitpack_block_bytes, in_size - block_start);
+                    const unsigned char *block_in = in_data + block_start;
+
+                    // The word data in the stream need not fall on the stream's own word grid (serialized metadata
+                    // is not always a multiple of eight bytes), so choose the phase that minimizes the encoded size
+                    // of the block.
+                    size_t phase = 0;
+                    int width = 0;
+                    size_t body_size = block_len;
+                    for (size_t p = 0; p <= min<size_t>(size_t(7), block_len); p++)
+                    {
+                        size_t words = block_word_count(block_len, p);
+                        uint64_t block_or = 0;
+                        for (size_t i = 0; i < words; i++)
+                        {
+                            uint64_t word = 0;
+                            memcpy(&word, block_in + p + i * bytes_per_word, bytes_per_word);
+                            block_or |= word;
+                        }
+                        int p_width = get_significant_bit_count(block_or);
+                        size_t p_body_size = block_body_size(block_len, p, p_width);
+                        if (p == 0 || p_body_size < body_size)
+                        {
+                            phase = p;
+                            width = p_width;
+                            body_size = p_body_size;
+                        }
+                    }
+                    size_t words = block_word_count(block_len, phase);
+
+                    out_data[out_pos++] = static_cast<unsigned char>(width);
+                    out_data[out_pos++] = static_cast<unsigned char>(phase);
+
+                    // Verbatim phase bytes
+                    memcpy(out_data + out_pos, block_in, phase);
+                    out_pos += phase;
+
+                    // Pack the words consecutively starting from the least significant bit. Each word carries at
+                    // most width significant bits, so nothing is lost; the read-modify-write below only ever ORs
+                    // significant bits into the zero-filled output.
+                    unsigned char *packed_out = out_data + out_pos;
+                    size_t bit_pos = 0;
+                    for (size_t i = 0; i < words; i++)
+                    {
+                        uint64_t word = 0;
+                        memcpy(&word, block_in + phase + i * bytes_per_word, bytes_per_word);
+                        size_t byte_index = bit_pos >> 3;
+                        int shift = static_cast<int>(bit_pos & size_t(7));
+                        uint64_t low_word = 0;
+                        memcpy(&low_word, packed_out + byte_index, bytes_per_word);
+                        low_word |= word << shift;
+                        memcpy(packed_out + byte_index, &low_word, bytes_per_word);
+                        if (shift && width > bits_per_uint64 - shift)
+                        {
+                            packed_out[byte_index + bytes_per_word] =
+                                static_cast<unsigned char>(word >> (bits_per_uint64 - shift));
+                        }
+                        bit_pos += static_cast<size_t>(width);
+                    }
+                    out_pos += (words * static_cast<size_t>(width) + size_t(7)) >> 3;
+
+                    // Verbatim tail bytes
+                    size_t tail = block_len - phase - words * bytes_per_word;
+                    memcpy(out_data + out_pos, block_in + block_len - tail, tail);
+                    out_pos += tail;
+
+                    block_start += block_len;
+                }
+
+                // Populate the header
+                header.compr_mode = compr_mode_type::bitpack;
+                header.size = static_cast<uint64_t>(add_safe(sizeof(Serialization::SEALHeader), out_pos));
+
+                auto old_except_mask = out_stream.exceptions();
+                try
+                {
+                    // Throw exceptions on ios_base::badbit and ios_base::failbit
+                    out_stream.exceptions(ios_base::badbit | ios_base::failbit);
+
+                    // Write the header and the data
+                    out_stream.write(reinterpret_cast<const char *>(&header), sizeof(Serialization::SEALHeader));
+                    out_stream.write(reinterpret_cast<const char *>(out_data), safe_cast<streamsize>(out_pos));
+                }
+                catch (...)
+                {
+                    out_stream.exceptions(old_except_mask);
+                    throw;
+                }
+
+                out_stream.exceptions(old_except_mask);
+            }
+
+            BitUnpackGetBuffer::BitUnpackGetBuffer(istream &in_stream, streamoff in_size, MemoryPoolHandle pool)
+                : in_buf_(allocate<unsigned char>(bitpack_block_bytes + block_slack, pool)),
+                  out_buf_(allocate<unsigned char>(bitpack_block_bytes, pool)), in_stream_(in_stream),
+                  in_remaining_(in_size), in_stream_except_mask_(in_stream.exceptions())
+            {
+                // Unpacking reports failure through failed_ rather than stream exceptions, so clear the mask while
+                // we read; it is restored in the destructor.
+                in_stream_.exceptions(ios_base::goodbit);
+
+                // Start with an empty get area so that the first read triggers underflow().
+                char_type *base = reinterpret_cast<char_type *>(out_buf_.get());
+                setg(base, base, base);
+            }
+
+            BitUnpackGetBuffer::~BitUnpackGetBuffer()
+            {
+                in_stream_.exceptions(in_stream_except_mask_);
+            }
+
+            streamsize BitUnpackGetBuffer::read_packed(unsigned char *dst, streamsize count)
+            {
+                streamsize to_read = min<streamsize>(count, in_remaining_);
+                if (to_read <= 0)
+                {
+                    return 0;
+                }
+                in_stream_.read(reinterpret_cast<char *>(dst), to_read);
+                streamsize got = in_stream_.gcount();
+                in_remaining_ -= got;
+                return got;
+            }
+
+            size_t BitUnpackGetBuffer::unpack_block()
+            {
+                if (finished_)
+                {
+                    return 0;
+                }
+
+                if (!started_)
+                {
+                    // The packed data begins with the original byte count
+                    unsigned char size_bytes[bytes_per_word];
+                    if (read_packed(size_bytes, static_cast<streamsize>(bytes_per_word)) !=
+                        static_cast<streamsize>(bytes_per_word))
+                    {
+                        failed_ = true;
+                        return 0;
+                    }
+                    memcpy(&raw_remaining_, size_bytes, bytes_per_word);
+                    started_ = true;
+                    if (!raw_remaining_)
+                    {
+                        finished_ = true;
+                        return 0;
+                    }
+                }
+
+                size_t block_len =
+                    static_cast<size_t>(min<uint64_t>(static_cast<uint64_t>(bitpack_block_bytes), raw_remaining_));
+
+                unsigned char block_header[2];
+                if (read_packed(block_header, 2) != 2)
+                {
+                    failed_ = true;
+                    return 0;
+                }
+                int width = static_cast<int>(block_header[0]);
+                size_t phase = static_cast<size_t>(block_header[1]);
+                if (width > bits_per_uint64 || phase > min<size_t>(size_t(7), block_len))
+                {
+                    failed_ = true;
+                    return 0;
+                }
+                size_t words = block_word_count(block_len, phase);
+                size_t packed_bytes = (words * static_cast<size_t>(width) + size_t(7)) >> 3;
+                size_t tail = block_len - phase - words * bytes_per_word;
+
+                // Verbatim phase bytes
+                if (read_packed(out_buf_.get(), safe_cast<streamsize>(phase)) != safe_cast<streamsize>(phase))
+                {
+                    failed_ = true;
+                    return 0;
+                }
+
+                if (read_packed(in_buf_.get(), safe_cast<streamsize>(packed_bytes)) !=
+                    safe_cast<streamsize>(packed_bytes))
+                {
+                    failed_ = true;
+                    return 0;
+                }
+
+                // Unpack the words. The whole-uint64_t reads may pick up bits past the packed data (block_slack
+                // bytes of headroom make them safe); the mask discards everything above the significant bits.
+                uint64_t mask = (width == bits_per_uint64) ? ~uint64_t(0) : ((uint64_t(1) << width) - 1);
+                size_t bit_pos = 0;
+                for (size_t i = 0; i < words; i++)
+                {
+                    size_t byte_index = bit_pos >> 3;
+                    int shift = static_cast<int>(bit_pos & size_t(7));
+                    uint64_t low_word = 0;
+                    memcpy(&low_word, in_buf_.get() + byte_index, bytes_per_word);
+                    low_word >>= shift;
+                    if (shift && width > bits_per_uint64 - shift)
+                    {
+                        uint64_t high_byte = in_buf_.get()[byte_index + bytes_per_word];
+                        low_word |= high_byte << (bits_per_uint64 - shift);
+                    }
+                    uint64_t word = low_word & mask;
+                    memcpy(out_buf_.get() + phase + i * bytes_per_word, &word, bytes_per_word);
+                    bit_pos += static_cast<size_t>(width);
+                }
+
+                // Verbatim tail bytes
+                if (read_packed(out_buf_.get() + block_len - tail, safe_cast<streamsize>(tail)) !=
+                    safe_cast<streamsize>(tail))
+                {
+                    failed_ = true;
+                    return 0;
+                }
+
+                raw_remaining_ -= block_len;
+                if (!raw_remaining_)
+                {
+                    finished_ = true;
+                }
+                return block_len;
+            }
+
+            BitUnpackGetBuffer::int_type BitUnpackGetBuffer::underflow()
+            {
+                if (gptr() < egptr())
+                {
+                    return traits_type::to_int_type(*gptr());
+                }
+
+                // Pull and unpack blocks until we produce output, reach the end of the data, or fail. unpack_block()
+                // guarantees progress: whenever it makes none it sets failed_ or finished_, so this loop always
+                // terminates.
+                while (!failed_)
+                {
+                    size_t produced = unpack_block();
+                    if (failed_)
+                    {
+                        break;
+                    }
+                    if (produced)
+                    {
+                        char_type *base = reinterpret_cast<char_type *>(out_buf_.get());
+                        setg(base, base, base + produced);
+                        total_produced_ += static_cast<streamoff>(produced);
+                        return traits_type::to_int_type(*gptr());
+                    }
+                    if (finished_)
+                    {
+                        return traits_type::eof();
+                    }
+                }
+                return traits_type::eof();
+            }
+
+            streamsize BitUnpackGetBuffer::xsgetn(char_type *s, streamsize count)
+            {
+                streamsize total = 0;
+                while (total < count)
+                {
+                    if (gptr() == egptr() && traits_type::eq_int_type(underflow(), traits_type::eof()))
+                    {
+                        break;
+                    }
+                    streamsize avail = min<streamsize>(count - total, static_cast<streamsize>(egptr() - gptr()));
+                    copy_n(gptr(), avail, s + total);
+
+                    // avail is at most bitpack_block_bytes, which is well within the range of int.
+                    gbump(static_cast<int>(avail));
+                    total += avail;
+                }
+                return total;
+            }
+
+            BitUnpackGetBuffer::pos_type BitUnpackGetBuffer::seekoff(
+                off_type off, ios_base::seekdir dir, ios_base::openmode which)
+            {
+                // Only a no-op seek to the current input position is supported, i.e. tellg(). The position is the
+                // number of unpacked bytes already consumed from the get area.
+                if (off == 0 && dir == ios_base::cur && (which & ios_base::in))
+                {
+                    return pos_type(total_produced_ - static_cast<off_type>(egptr() - gptr()));
+                }
+                return pos_type(off_type(-1));
+            }
+
+            unique_ptr<BitUnpackGetBuffer> make_bitpack_unpack_buffer(
+                istream &in_stream, streamoff in_size, MemoryPoolHandle pool)
+            {
+                return make_unique<BitUnpackGetBuffer>(in_stream, in_size, std::move(pool));
+            }
+        } // namespace bitpack
+    } // namespace util
+} // namespace seal

--- a/native/src/seal/util/bitpack.h
+++ b/native/src/seal/util/bitpack.h
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include "seal/dynarray.h"
+#include "seal/memorymanager.h"
+#include "seal/util/common.h"
+#include "seal/util/defines.h"
+#include "seal/util/pointer.h"
+#include <cstddef>
+#include <cstdint>
+#include <ios>
+#include <iostream>
+#include <memory>
+#include <streambuf>
+
+namespace seal
+{
+    namespace util
+    {
+        namespace bitpack
+        {
+            /**
+            The functions in this namespace implement the compr_mode_type::bitpack encoding of a serialized byte
+            stream. The stream is split into blocks of bitpack_block_bytes bytes; in each block, a run of 64-bit
+            words is re-encoded using only as many bits per word as the largest word in the run requires, so each
+            word begins immediately after the last significant bit of the previous one, even in the middle of a
+            byte. Since ciphertext and key data consist of words storing integers modulo primes much smaller than
+            the word size, and the significant bits are high-entropy, this discards exactly the always-zero high
+            bits that a general-purpose compressor cannot improve upon.
+
+            Serialized metadata is not always a multiple of eight bytes, so the word data in the stream need not
+            fall on the stream's own word grid. Each block therefore carries a phase: the number of initial bytes
+            (0 to 7) stored verbatim before the packed run, chosen by the encoder to minimize the encoded size of
+            the block. Bytes after the last whole word in the block are likewise stored verbatim.
+
+            The encoded format is, in order:
+
+            1. the size in bytes of the original byte stream (8 bytes)
+            2. for each block of block_len = min(bitpack_block_bytes, bytes remaining) original bytes:
+               a. the bit width used for the packed words (1 byte, at most 64)
+               b. the phase (1 byte, at most min(7, block_len))
+               c. phase verbatim bytes
+               d. the (block_len - phase) / 8 words packed consecutively starting from the least significant bit
+               e. the remaining (block_len - phase) % 8 bytes verbatim
+
+            A width of zero denotes words that are all zero, packed into no bytes at all. Like the rest of the
+            serialized data, the encoding is in the byte order of the host.
+            */
+
+            // Number of original bytes encoded in each bit-packed block.
+            constexpr std::size_t bitpack_block_bytes = 4096;
+
+            /**
+            Bit-packs data in the given buffer, completes the given SEALHeader by writing in the size of the output
+            and setting the compression mode to compr_mode_type::bitpack and finally writes the SEALHeader followed
+            by the bit-packed data in the given stream.
+
+            @param[in] in The buffer to bit-pack
+            @param[out] header_ptr A pointer to a SEALHeader instance matching the output of the encoding
+            @param[out] out_stream The stream to write to
+            @param[in] pool The MemoryPoolHandle pointing to a valid memory pool
+            @throws std::invalid_argument if pool is uninitialized
+            @throws std::runtime_error if I/O operations failed
+            */
+            void bitpack_write_header_pack_buffer(
+                const DynArray<seal_byte> &in, void *header_ptr, std::ostream &out_stream, MemoryPoolHandle pool);
+
+            /**
+            A get-only stream buffer that unpacks bit-packed data from an underlying input stream on demand, one
+            block at a time, instead of decoding the entire payload up front into a single growing buffer. Because
+            the parser only pulls as many bytes as its (validated) parameters require, this bounds the memory used
+            during deserialization to a small constant, defending against hostile size claims in the encoded data.
+            The buffer is forward-only: it reports the current read position (so tellg() works, which nested loads
+            rely on) but does not support repositioning.
+            */
+            class BitUnpackGetBuffer final : public std::streambuf
+            {
+            public:
+                BitUnpackGetBuffer(std::istream &in_stream, std::streamoff in_size, MemoryPoolHandle pool);
+
+                ~BitUnpackGetBuffer() override;
+
+                BitUnpackGetBuffer(const BitUnpackGetBuffer &copy) = delete;
+
+                BitUnpackGetBuffer &operator=(const BitUnpackGetBuffer &assign) = delete;
+
+                // True if malformed or truncated input was encountered while pulling data.
+                SEAL_NODISCARD bool failed() const noexcept
+                {
+                    return failed_;
+                }
+
+                // Number of packed bytes from the bound that have not yet been read from the underlying stream.
+                SEAL_NODISCARD std::streamoff remaining() const noexcept
+                {
+                    return in_remaining_;
+                }
+
+            private:
+                // Unpacks the next block into out_buf_, returning the number of bytes produced. Sets finished_ when
+                // all of the original bytes have been produced and failed_ on malformed or truncated input.
+                std::size_t unpack_block();
+
+                // Reads up to count packed bytes from the underlying stream, capped by the remaining bound. Returns
+                // the number of bytes actually read.
+                std::streamsize read_packed(unsigned char *dst, std::streamsize count);
+
+                int_type underflow() override;
+
+                std::streamsize xsgetn(char_type *s, std::streamsize count) override;
+
+                // Supports only tellg() (a no-op seek to the current input position); any other seek fails. This is
+                // enough for the nested loads that verify their size via tellg().
+                pos_type seekoff(
+                    off_type off, std::ios_base::seekdir dir,
+                    std::ios_base::openmode which = std::ios_base::in | std::ios_base::out) override;
+
+                Pointer<unsigned char> in_buf_;
+
+                Pointer<unsigned char> out_buf_;
+
+                std::istream &in_stream_;
+
+                std::streamoff in_remaining_;
+
+                std::ios_base::iostate in_stream_except_mask_;
+
+                // Number of original bytes that remain to be produced; valid once started_ is set.
+                std::uint64_t raw_remaining_ = 0;
+
+                bool started_ = false;
+
+                bool failed_ = false;
+
+                bool finished_ = false;
+
+                // Total unpacked bytes handed to the get area so far; used to report the read position.
+                std::streamoff total_produced_ = 0;
+            };
+
+            // Creates a streambuf that unpacks in_size bytes of bit-packed data from in_stream on demand.
+            std::unique_ptr<BitUnpackGetBuffer> make_bitpack_unpack_buffer(
+                std::istream &in_stream, std::streamoff in_size, MemoryPoolHandle pool);
+
+            template <typename SizeT>
+            SEAL_NODISCARD SizeT bitpack_size_bound(SizeT in_size)
+            {
+                // 8 bytes for the original size and a width and a phase byte per block of bitpack_block_bytes =
+                // 4096 original bytes (plus rounding up); the blocks themselves never exceed their original size.
+                return util::add_safe<SizeT>(in_size, in_size >> 11, SizeT(17));
+            }
+        } // namespace bitpack
+    } // namespace util
+} // namespace seal

--- a/native/tests/seal/ciphertext.cpp
+++ b/native/tests/seal/ciphertext.cpp
@@ -127,6 +127,52 @@ namespace sealtest
         ASSERT_TRUE(ctxt.data() != ctxt2.data());
     }
 
+    TEST(CiphertextTest, BFVBitPackSaveLoadCiphertext)
+    {
+        stringstream stream;
+        EncryptionParameters parms(scheme_type::bfv);
+        parms.set_poly_modulus_degree(1024);
+        parms.set_coeff_modulus(CoeffModulus::BFVDefault(1024));
+        parms.set_plain_modulus(0xF0F0);
+
+        SEALContext context(parms, false);
+        KeyGenerator keygen(context);
+        PublicKey pk;
+        keygen.create_public_key(pk);
+        Encryptor encryptor(context, pk);
+
+        Ciphertext ctxt;
+        encryptor.encrypt(Plaintext("Ax^10 + 9x^9 + 8x^8 + 7x^7 + 6x^6 + 5x^5 + 4x^4 + 3x^3 + 2x^2 + 1"), ctxt);
+
+        // A bit-packed round-trip preserves the ciphertext exactly
+        auto bitpack_size = ctxt.save(stream, compr_mode_type::bitpack);
+        Ciphertext ctxt2;
+        ctxt2.load(context, stream);
+        ASSERT_TRUE(ctxt.parms_id() == ctxt2.parms_id());
+        ASSERT_TRUE(
+            is_equal_uint(ctxt.data(), ctxt2.data(), parms.poly_modulus_degree() * parms.coeff_modulus().size() * 2));
+        ASSERT_TRUE(ctxt.data() != ctxt2.data());
+
+        // The first block contains the ciphertext metadata (among it full-width parms_id hash words) and packs at
+        // up to the full 64 bits, but every later block holds only coefficients smaller than the coefficient
+        // modulus primes and hence packs at their bit width, so the total is guaranteed to beat the unpacked size.
+        ASSERT_LT(bitpack_size, ctxt.save_size(compr_mode_type::none));
+
+        // Seeded ciphertexts bit-pack too: the same seeded object saved with and without bit-packing must load to
+        // identical data
+        Encryptor sym_encryptor(context, keygen.secret_key());
+        auto seeded = sym_encryptor.encrypt_symmetric(Plaintext("3x^7 + 2"));
+        stringstream seeded_stream;
+        seeded.save(seeded_stream, compr_mode_type::bitpack);
+        seeded.save(seeded_stream, compr_mode_type::none);
+        Ciphertext from_bitpack, from_none;
+        from_bitpack.load(context, seeded_stream);
+        from_none.load(context, seeded_stream);
+        ASSERT_TRUE(from_bitpack.parms_id() == from_none.parms_id());
+        ASSERT_TRUE(is_equal_uint(
+            from_bitpack.data(), from_none.data(), parms.poly_modulus_degree() * parms.coeff_modulus().size() * 2));
+    }
+
     TEST(CiphertextTest, LoadZeroSizeRejectsOversizedDynArray)
     {
         EncryptionParameters parms(scheme_type::bfv);

--- a/native/tests/seal/serialization.cpp
+++ b/native/tests/seal/serialization.cpp
@@ -79,6 +79,35 @@ namespace sealtest
             }
         };
 
+        // A serializable object whose payload is a sequence of 64-bit words, mirroring how real SEAL objects store
+        // coefficient data; used to pin down the exact bit-packed output size.
+        struct word_struct
+        {
+            std::vector<uint64_t> words;
+
+            void save_members(ostream &stream)
+            {
+                uint64_t n = static_cast<uint64_t>(words.size());
+                stream.write(reinterpret_cast<const char *>(&n), sizeof(uint64_t));
+                stream.write(reinterpret_cast<const char *>(words.data()), static_cast<streamsize>(words.size() * 8));
+            }
+
+            void load_members(istream &stream)
+            {
+                uint64_t n = 0;
+                stream.read(reinterpret_cast<char *>(&n), sizeof(uint64_t));
+                words.resize(static_cast<size_t>(n));
+                stream.read(reinterpret_cast<char *>(words.data()), static_cast<streamsize>(n * 8));
+            }
+
+            streamoff save_size(compr_mode_type compr_mode) const
+            {
+                size_t raw = sizeof(uint64_t) + words.size() * 8;
+                return static_cast<streamoff>(
+                    sizeof(Serialization::SEALHeader) + Serialization::ComprSizeEstimate(raw, compr_mode));
+            }
+        };
+
         // A serializable object that, on save, writes a small prefix followed by a large filler, but on load reads
         // only the prefix. Modeling a hostile/oversized payload: the loader must not need to inflate the unread filler
         // (the decompression-bomb defense), and must leave the stream positioned at the end of the object.
@@ -240,6 +269,22 @@ namespace sealtest
 #ifdef SEAL_USE_ZSTD
             modes.push_back(compr_mode_type::zstd);
 #endif
+            modes.push_back(compr_mode_type::bitpack);
+            return modes;
+        }
+
+        // The compression modes that verify the integrity of the compressed data on load. Bit-packing performs no
+        // integrity checking: corrupted packed bits decode to wrong values rather than a detected error, like
+        // compr_mode_type::none.
+        std::vector<compr_mode_type> checksummed_compr_modes()
+        {
+            std::vector<compr_mode_type> modes;
+#ifdef SEAL_USE_ZLIB
+            modes.push_back(compr_mode_type::zlib);
+#endif
+#ifdef SEAL_USE_ZSTD
+            modes.push_back(compr_mode_type::zstd);
+#endif
             return modes;
         }
     } // namespace
@@ -269,7 +314,9 @@ namespace sealtest
         invalid_header.version_major = 0x02;
         ASSERT_FALSE(Serialization::IsValidHeader(invalid_header));
         invalid_header.version_major = SEAL_VERSION_MAJOR;
-        invalid_header.compr_mode = (compr_mode_type)0x03;
+        invalid_header.compr_mode = compr_mode_type::bitpack;
+        ASSERT_TRUE(Serialization::IsValidHeader(invalid_header));
+        invalid_header.compr_mode = (compr_mode_type)0x04;
         ASSERT_FALSE(Serialization::IsValidHeader(invalid_header));
     }
 
@@ -430,6 +477,17 @@ namespace sealtest
             ASSERT_EQ(st.c, st3.c);
         }
 #endif
+        {
+            test_struct st3;
+            out_size = Serialization::Save(
+                bind(&test_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), stream,
+                compr_mode_type::bitpack, false);
+            in_size = Serialization::Load(bind(&test_struct::load_members, &st3, _1), stream, false);
+            ASSERT_EQ(out_size, in_size);
+            ASSERT_EQ(st.a, st3.a);
+            ASSERT_EQ(st.b, st3.b);
+            ASSERT_EQ(st.c, st3.c);
+        }
     }
 
     TEST(SerializationTest, SaveLoadToBuffer)
@@ -510,6 +568,30 @@ namespace sealtest
             ASSERT_EQ(st.c, st3.c);
         }
 #endif
+        {
+            // Reset buffer back to zero
+            memset(buffer, 0, arr_size);
+
+            test_struct st3;
+            ss.seekp(0);
+            test_out_size = Serialization::Save(
+                bind(&test_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), ss,
+                compr_mode_type::bitpack, false);
+            out_size = Serialization::Save(
+                bind(&test_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), buffer, arr_size,
+                compr_mode_type::bitpack, false);
+            ASSERT_EQ(test_out_size, out_size);
+            for (size_t i = static_cast<size_t>(out_size); i < arr_size; i++)
+            {
+                ASSERT_EQ(seal_byte{}, buffer[i]);
+            }
+
+            in_size = Serialization::Load(bind(&test_struct::load_members, &st3, _1), buffer, arr_size, false);
+            ASSERT_EQ(out_size, in_size);
+            ASSERT_EQ(st.a, st3.a);
+            ASSERT_EQ(st.b, st3.b);
+            ASSERT_EQ(st.c, st3.c);
+        }
     }
 
     // Round-trips a payload larger than the 256 KB internal decompression buffer to exercise multi-chunk streaming
@@ -624,7 +706,7 @@ namespace sealtest
             st.data[i] = static_cast<uint8_t>((i * 2654435761ULL) >> 24);
         }
 
-        for (auto mode : available_compr_modes())
+        for (auto mode : checksummed_compr_modes())
         {
             stringstream stream;
             Serialization::Save(bind(&large_struct::save_members, &st, _1), st.save_size(mode), stream, mode, false);
@@ -802,5 +884,157 @@ namespace sealtest
             // Consumes the nested object plus a bounded number of decompression buffers, never the 8 MB filler.
             ASSERT_LT(buf.consumed(), streamsize(1) << 20);
         }
+    }
+
+    // Bit-packing an all-word payload of bounded-width values must produce exactly the size the format prescribes
+    // (8 bytes for the original size, then per block a width byte, a phase byte, and the packed words) and must
+    // round-trip.
+    TEST(SerializationTest, BitPackSizeAndRoundTrip)
+    {
+        using namespace placeholders;
+
+        // 1023 values of at most 36 significant bits; with the 8-byte count in front, the serialized stream is
+        // exactly 8192 bytes, i.e. two full blocks of 512 word-aligned words each (phase 0, no verbatim bytes).
+        word_struct st;
+        st.words.resize(1023);
+        uint64_t state = 1;
+        for (size_t i = 0; i < st.words.size(); i++)
+        {
+            state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+            st.words[i] = state & ((uint64_t(1) << 36) - 1);
+        }
+
+        // Pin the width of both blocks to exactly 36 bits. The stream words are the count followed by the values,
+        // so the second block starts at value index 511.
+        st.words[0] |= uint64_t(1) << 35;
+        st.words[511] |= uint64_t(1) << 35;
+
+        stringstream stream;
+        auto out_size = Serialization::Save(
+            bind(&word_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), stream,
+            compr_mode_type::bitpack, false);
+
+        // 16 (SEALHeader) + 8 (original size) + 2 * (1 width byte + 1 phase byte + 512 * 36 / 8)
+        ASSERT_EQ(16 + 8 + 2 * (2 + 2304), out_size);
+
+        word_struct st2;
+        auto in_size = Serialization::Load(bind(&word_struct::load_members, &st2, _1), stream, false);
+        ASSERT_EQ(out_size, in_size);
+        ASSERT_TRUE(st.words == st2.words);
+    }
+
+    // The encoder must find word data that does not fall on the stream's own word grid: values shifted off the
+    // grid by a 1-byte prefix (as a seal_byte member does in real objects) must still pack at their bit width,
+    // costing only the per-block phase bytes relative to the aligned encoding.
+    TEST(SerializationTest, BitPackMisalignedWords)
+    {
+        using namespace placeholders;
+
+        word_struct aligned;
+        aligned.words.resize(1023);
+        uint64_t state = 12345;
+        for (size_t i = 0; i < aligned.words.size(); i++)
+        {
+            state = state * 6364136223846793005ULL + 1442695040888963407ULL;
+            aligned.words[i] = state & ((uint64_t(1) << 36) - 1);
+        }
+
+        struct prefixed_word_struct
+        {
+            word_struct inner;
+
+            void save_members(ostream &stream)
+            {
+                seal_byte prefix{};
+                stream.write(reinterpret_cast<const char *>(&prefix), 1);
+                inner.save_members(stream);
+            }
+
+            streamoff save_size(compr_mode_type compr_mode) const
+            {
+                size_t raw = 1 + sizeof(uint64_t) + inner.words.size() * 8;
+                return static_cast<streamoff>(
+                    sizeof(Serialization::SEALHeader) + Serialization::ComprSizeEstimate(raw, compr_mode));
+            }
+        };
+        prefixed_word_struct st;
+        st.inner = aligned;
+
+        stringstream aligned_stream;
+        auto aligned_size = Serialization::Save(
+            bind(&word_struct::save_members, &aligned, _1), aligned.save_size(compr_mode_type::bitpack), aligned_stream,
+            compr_mode_type::bitpack, false);
+
+        stringstream prefixed_stream;
+        auto prefixed_size = Serialization::Save(
+            bind(&prefixed_word_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), prefixed_stream,
+            compr_mode_type::bitpack, false);
+
+        // The prefixed stream is 1 original byte longer and spans 3 blocks instead of 2; the packed words must
+        // not grow beyond the extra verbatim and block-header bytes.
+        ASSERT_LE(prefixed_size, aligned_size + 16);
+    }
+
+    // A width byte exceeding 64 is malformed and must be rejected cleanly.
+    TEST(SerializationTest, BitPackTamperedWidthThrows)
+    {
+        using namespace placeholders;
+
+        test_struct st{ 3, ~0, 3.14159 };
+        stringstream ss;
+        Serialization::Save(
+            bind(&test_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), ss,
+            compr_mode_type::bitpack, false);
+
+        // The first block's width byte follows the SEALHeader (16 bytes) and the original size (8 bytes).
+        string bytes = ss.str();
+        bytes[24] = static_cast<char>(65);
+
+        stringstream tampered(bytes);
+        test_struct st2;
+        ASSERT_ANY_THROW(Serialization::Load(bind(&test_struct::load_members, &st2, _1), tampered, false));
+    }
+
+    // A phase byte exceeding 7 is malformed and must be rejected cleanly.
+    TEST(SerializationTest, BitPackTamperedPhaseThrows)
+    {
+        using namespace placeholders;
+
+        test_struct st{ 3, ~0, 3.14159 };
+        stringstream ss;
+        Serialization::Save(
+            bind(&test_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), ss,
+            compr_mode_type::bitpack, false);
+
+        // The first block's phase byte follows the SEALHeader (16 bytes), the original size (8 bytes), and the
+        // width byte.
+        string bytes = ss.str();
+        bytes[25] = static_cast<char>(8);
+
+        stringstream tampered(bytes);
+        test_struct st2;
+        ASSERT_ANY_THROW(Serialization::Load(bind(&test_struct::load_members, &st2, _1), tampered, false));
+    }
+
+    // An understated original size makes the parser read past the end of the unpacked data and must be rejected
+    // cleanly.
+    TEST(SerializationTest, BitPackTamperedSizeThrows)
+    {
+        using namespace placeholders;
+
+        test_struct st{ 3, ~0, 3.14159 };
+        stringstream ss;
+        Serialization::Save(
+            bind(&test_struct::save_members, &st, _1), st.save_size(compr_mode_type::bitpack), ss,
+            compr_mode_type::bitpack, false);
+
+        // The original size is the 8 bytes following the SEALHeader; understate it below what load_members reads.
+        string bytes = ss.str();
+        uint64_t small_size = 8;
+        memcpy(&bytes[16], &small_size, sizeof(uint64_t));
+
+        stringstream tampered(bytes);
+        test_struct st2;
+        ASSERT_ANY_THROW(Serialization::Load(bind(&test_struct::load_members, &st2, _1), tampered, false));
     }
 } // namespace sealtest


### PR DESCRIPTION
## Summary

This PR adds a new serialization mode, `compr_mode_type::bitpack` (native) / `ComprModeType.BitPack` (dotnet), that serializes each coefficient immediately after the last significant bit of the previous one, even in the middle of a byte.

Ciphertext and key data consist of 64-bit words storing integers modulo primes much smaller than the word size.
The significant bits of those words are close to uniformly random and hence essentially incompressible; the only redundancy is the always-zero high bits.
ZLIB and Zstandard can remove the zero bytes but not the partial ones, so bit-packing consistently beats them on this data.

Measured on BFV objects (macOS arm64, Release):

| Object | `none` | `zlib` | `zstd` | `bitpack` |
|---|---|---|---|---|
| Ciphertext, n=4096, q={36,36} bits | 131,185 | 91,131 | 88,595 | **75,726** (58% of raw, 15% below zstd) |
| Ciphertext, n=8192, q={43,43,44,44} bits | 524,401 | 427,232 | 432,512 | **358,490** (68% of raw, 17% below zstd) |
| RelinKeys, n=8192 | 2,621,956 | — | 2,167,496 | **1,795,047** (17% below zstd) |

The n=8192 ratio (68.4%) is essentially the information-theoretic floor for 44-bit primes (44/64 = 68.75%); the remainder is the metadata-carrying first block.

## Design

The mode is implemented entirely inside the generic `Serialization::Save`/`Load` dispatch, exactly like zlib/zstd, with the codec in a new `seal::util::bitpack` namespace (`native/src/seal/util/bitpack.h/.cpp`):

- The `save_members` output stream is split into 4096-byte blocks; each block's run of 64-bit words is packed at the bit width of the largest word in the block (width byte per block).
This keeps the encoding self-describing — no modulus knowledge is needed, so `save_size()` keeps its context-free signature and every serializable type (including seeded `Serializable<T>` objects and the nested frames inside `KSwitchKeys`) works unchanged.
For uniformly random coefficients modulo a b-bit prime, the block width equals b with overwhelming probability, so this matches modulus-aware packing; on sparse data (plaintexts, zero polynomials) it does strictly better.
- Serialized metadata is not always a multiple of eight bytes (e.g. the `seal_byte is_ntt_form` field), so coefficient arrays generally do not fall on the stream's own word grid.
Each block therefore carries a phase byte: up to 7 verbatim leading bytes, chosen to minimize the encoded block size, that realign the packed run with the data's natural word grid.
Without this the misalignment costs 8 bits per word and bit-packing loses to zstd; with it the numbers above hold.
- Loading is streamed one block at a time through a pull-based `BitUnpackGetBuffer`, mirroring `ztools::InflateGetBuffer`, so memory use during loading is bounded by a small constant and hostile size claims in the packed data cannot drive unbounded allocation.
Width and phase bytes are validated; truncated input is rejected cleanly.

## Compatibility

- The wire format of all existing modes and the default compression mode are unchanged.
- Loading all previously serialized data is unaffected.
- Objects serialized with the new mode are rejected cleanly by earlier releases via the existing `IsSupportedComprMode` check in `IsValidHeader` (the same behavior as a zstd stream loaded by a build without zstd).
The maintainers may want to gate the release of this mode on a minor version bump, matching the precedent of Zstandard support in 3.6.
- The mode has no external dependency and is always available (no CMake option, no `#ifdef` in the enum).
- Unlike zlib/zstd, bit-packing performs no integrity checking of the data (like `compr_mode_type::none`); this is documented on the enum.

## Tests

- `SerializationTest.BitPackSizeAndRoundTrip` pins the exact encoded size of a word-aligned payload and round-trips it.
- `SerializationTest.BitPackMisalignedWords` verifies off-grid word data still packs at its bit width.
- `SerializationTest.BitPackTamperedWidthThrows` / `BitPackTamperedPhaseThrows` / `BitPackTamperedSizeThrows` cover malformed input.
- `CiphertextTest.BFVBitPackSaveLoadCiphertext` round-trips a real ciphertext (including a seeded one) and asserts the packed size beats `none`.
- The new mode is added to the shared `available_compr_modes()` loop, so the existing streaming, partial-consumption, bomb-shape, truncation, non-seekable-stream, and nested-frame hardening tests all run against it.
The corruption-detection test now iterates a `checksummed_compr_modes()` list, since bit-packing (like `none`) has no checksum.
- .NET: `ComprModeType.BitPack` added with `SerializationTests`/`CiphertextTests` coverage.

Verified locally on macOS arm64: full `sealtest` (324 tests) and `sealctest` pass in Release, and the serialization/ciphertext suites also pass in C++14 mode (`SEAL_USE_CXX17=OFF`) with zero warnings.
The .NET test additions are compile-checked by inspection only (no .NET 10 SDK on this machine); CI will exercise them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
